### PR TITLE
[FEAT] 닉네임/가족 등록 기능 & 스케줄 알림 기능

### DIFF
--- a/Howsu/app/build.gradle.kts
+++ b/Howsu/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.foundation.layout)
+    implementation(libs.material3)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/Howsu/app/src/main/AndroidManifest.xml
+++ b/Howsu/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+
     <queries>
         <package android:name="com.kakao.talk" />
         <package android:name="com.google.android.gms" />
@@ -52,6 +56,10 @@
             android:screenOrientation="portrait"
             android:exported="true" />
 
+        <receiver
+            android:name=".screen.schedule.AlarmReceiver"
+            android:enabled="true"
+            android:exported="false" />
 
     </application>
 

--- a/Howsu/app/src/main/AndroidManifest.xml
+++ b/Howsu/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
@@ -15,6 +13,7 @@
     </queries>
 
     <application
+        android:name=".GlobalApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -22,8 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Howsu"
-        android:name=".GlobalApplication">
+        android:theme="@style/Theme.Howsu">
 
         <activity
             android:name=".MainActivity"
@@ -46,7 +44,7 @@
 
                 <data
                     android:host="oauth"
-                    android:scheme="kakao{1a7e2a324c2da34b577405598eef2d03}" />
+                    android:scheme="kakao1a7e2a324c2da34b577405598eef2d03" />
             </intent-filter>
         </activity>
 

--- a/Howsu/app/src/main/java/com/example/howsu/Pet/PetRegisterViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/Pet/PetRegisterViewModel.kt
@@ -1,0 +1,158 @@
+package com.example.howsu.Pet
+
+import androidx.lifecycle.ViewModel
+import com.example.howsu.data.model.BirthdayInputType
+import com.example.howsu.data.model.FamilyMember
+import com.example.howsu.data.model.Pet
+import com.example.howsu.data.model.PetRegisterStep
+import com.example.howsu.data.model.PetRegisterUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+class PetRegisterViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PetRegisterUiState())
+    val uiState: StateFlow<PetRegisterUiState> = _uiState
+
+    // 닉네임
+    fun updateNickName(value: String) =
+        _uiState.update { it.copy(nickName = value) }
+
+    // 반려동물 이름
+    fun updatePetName(value: String) =
+        _uiState.update { it.copy(petName = value) }
+
+    // (혹시 옛날 코드에서 updateName을 쓰고 있으면 대비용)
+    fun updateName(value: String) = updatePetName(value)
+
+    // 성별
+    fun updateGender(g: String) =
+        _uiState.update { it.copy(gender = g) }
+
+    // 몸무게
+    fun updateWeight(value: String) =
+        _uiState.update { it.copy(weight = value) }
+
+    //유저 프로필 이미지
+    fun updateUserProfileImage(url: String?) =
+        _uiState.update { it.copy(profileUserImageUrl = url) }
+
+    // 반려동물 프로필 이미지
+    fun updatePetProfileImage(url: String?) =
+        _uiState.update { it.copy(profilePetImageUrl = url) }
+
+    // 생일 입력 타입 (정확/대략)
+    fun updateBirthdayType(type: BirthdayInputType) =
+        _uiState.update { it.copy(birthdayInputType = type) }
+
+    // 정확한 생일
+    fun updateBirthdayExact(date: String) =
+        _uiState.update { it.copy(birthdayExact = date) }
+
+    // 대략적 생년 (년도)
+    fun updateBirthdayYear(year: String) =
+        _uiState.update { it.copy(birthdayYearApprox = year) }
+
+    // 대략적 생년 (월)
+    fun updateBirthdayMonth(month: String) =
+        _uiState.update { it.copy(birthdayMonthApprox = month) }
+
+    // 중성화 여부
+    fun updateNeutered(isNeutered: Boolean) =
+        _uiState.update { it.copy(isNeutered = isNeutered) }
+
+    // 다음 단계로 이동
+    fun nextStep() {
+        _uiState.update { s ->
+            val next = when (s.step) {
+                PetRegisterStep.NICKNAME      -> PetRegisterStep.PHOTO_NAME
+                PetRegisterStep.PHOTO_NAME    -> PetRegisterStep.GENDER_WEIGHT
+                PetRegisterStep.GENDER_WEIGHT -> PetRegisterStep.BIRTHDAY
+                PetRegisterStep.BIRTHDAY      -> PetRegisterStep.BIRTHDAY
+            }
+            s.copy(step = next)
+        }
+    }
+
+    // 이전 단계로 이동
+    fun previousStep() {
+       _uiState.update { s ->
+            val prev = when (s.step) {
+                PetRegisterStep.NICKNAME      -> PetRegisterStep.NICKNAME
+                PetRegisterStep.PHOTO_NAME    -> PetRegisterStep.NICKNAME
+                PetRegisterStep.GENDER_WEIGHT -> PetRegisterStep.PHOTO_NAME
+                PetRegisterStep.BIRTHDAY      -> PetRegisterStep.GENDER_WEIGHT
+            }
+            s.copy(step = prev)
+        }
+    }
+
+    // 다음 버튼 활성화 여부
+    fun isNextEnabled(): Boolean {
+        val s = _uiState.value
+        return when (s.step) {
+
+            // 닉네임 단계
+            PetRegisterStep.NICKNAME ->
+                s.nickName.isNotBlank()
+
+            // 반려동물 이름 단계
+            PetRegisterStep.PHOTO_NAME ->
+                s.petName.isNotBlank()
+
+            // 성별 + 몸무게 단계
+            PetRegisterStep.GENDER_WEIGHT ->
+                s.gender != null && s.weight.isNotBlank()
+
+            // 생일 단계
+            PetRegisterStep.BIRTHDAY ->
+                when (s.birthdayInputType) {
+                    BirthdayInputType.EXACT ->
+                        s.birthdayExact.isNotBlank()
+
+                    BirthdayInputType.APPROX ->
+                        s.birthdayYearApprox.isNotBlank() &&
+                                s.birthdayMonthApprox.isNotBlank()
+                }
+        }
+    }
+
+    // 저장
+    fun submit(onFinished: (Pet) -> Unit) {
+        val s = _uiState.value
+
+        val pet = Pet(
+            name = s.petName,
+            gender = s.gender,
+            profileImageUrl = s.profilePetImageUrl,
+            weight = s.weight,
+            birthdayInputType = s.birthdayInputType,
+            birthdayExact = s.birthdayExact.ifBlank { null },
+            birthdayYearApprox = s.birthdayYearApprox.ifBlank { null },
+            birthdayMonthApprox = s.birthdayMonthApprox.ifBlank { null },
+        )
+
+        onFinished(pet)
+    }
+
+    fun resetForNewPet() {
+        _uiState.update { s ->
+            // 닉네임/내 프로필 사진은 그대로 두고,
+            // 반려동물 정보만 초기화
+            s.copy(
+                step = PetRegisterStep.PHOTO_NAME,
+                petName = "",
+                gender = null,
+                weight = "",
+                isNeutered = null,
+                birthdayInputType = BirthdayInputType.EXACT,
+                birthdayExact = "",
+                birthdayYearApprox = "",
+                birthdayMonthApprox = ""
+            )
+        }
+    }
+}
+
+

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/Family.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/Family.kt
@@ -1,0 +1,10 @@
+package com.example.howsu.data.model
+
+data class Family(
+    val familyId: String,       // 가족 고유 ID (초대 코드로 사용, 예: "sda@1234")
+    val familyName: String,     // 가족 이름 (예: "루비네", "나혼자산다")
+    val ownerUserId: String,    // 방장(생성자)의 uid
+    val isSoloMode: Boolean = false, // ★ 중요: 혼자 쓰기 모드 여부
+    val memberIds: List<String> = emptyList(), // 이 가족에 속한 멤버 uid 리스트
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/FamilyMember.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/FamilyMember.kt
@@ -1,8 +1,9 @@
 package com.example.howsu.data.model
 
 data class FamilyMember(
-    val userId: String,        // 사용자 고유 ID (알림 보낼 때 필요)
-    val relationship: String,  // 관계
-    val profileImageUrl: String?, // 프로필 사진 URL (Coil 등으로 로드)
-    val nickName : String // 사용자 닉네임
+    val userId: String,        // User의 uid (누구인가?)
+    val familyId: String,      // Family의 familyId (어느 방인가?)
+    val nickName: String,      // 이 방에서 불릴 닉네임 (예: "엄마", "집사")
+    val relationship: String,  // 호칭/역할 (예: "보호자", "언니")
+    val profileImageUrl: String? = null
 )

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/Pet.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/Pet.kt
@@ -1,7 +1,24 @@
 package com.example.howsu.data.model
 
+enum class BirthdayInputType {
+    EXACT,      // 정확한 생일(날짜)
+    APPROX      // 대략적인 년/월
+}
+
 data class Pet(
-    val petId: String,
-    val name: String,
-    val profileImageUrl: String? // 프로필 사진 URL (Coil 등으로 로드)
+    val strp: PetRegisterStep = PetRegisterStep.PHOTO_NAME,
+    val petId: String? = null,
+    val name: String = "",
+    val gender: String? = null,
+    val profileImageUrl: String? = null, // 프로필 사진 URL (Coil 등으로 로드)
+    val weight: String? = null,
+    val isNeutered: Boolean? = null, //중성화 여부
+
+    // 생일 관련
+    val birthdayInputType: BirthdayInputType = BirthdayInputType.EXACT,
+    val birthdayExact: String? = "",        // YYYY-MM-DD
+    val birthdayYearApprox: String? = "",   // YYYY
+    val birthdayMonthApprox: String? = ""   // 1~12
 )
+
+

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/PetRegisterStep.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/PetRegisterStep.kt
@@ -1,0 +1,9 @@
+package com.example.howsu.data.model
+
+//단계
+enum class PetRegisterStep {
+    NICKNAME,        // 0: 닉네임 등록 (필수)
+    PHOTO_NAME,      // 1: 사진 + 이름
+    GENDER_WEIGHT,   // 2: 성별 + 몸무게
+    BIRTHDAY         // 3: 생년월일
+}

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/PetRegisterUiState.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/PetRegisterUiState.kt
@@ -1,0 +1,22 @@
+package com.example.howsu.data.model
+
+
+//입력 중인 임시 단계 데이터
+data class PetRegisterUiState(
+    val step: PetRegisterStep = PetRegisterStep.NICKNAME,
+
+    val nickName: String = "",
+    val petName: String = "",
+    val gender: String? = null,
+
+    val profileUserImageUrl: String? = null,   // 유저 프로필
+    val profilePetImageUrl: String? = null,    // 펫 프로필
+
+    val weight: String = "",
+    val isNeutered: Boolean? = null,
+
+    val birthdayInputType: BirthdayInputType = BirthdayInputType.EXACT,
+    val birthdayExact: String = "",
+    val birthdayYearApprox: String = "",
+    val birthdayMonthApprox: String = ""
+)

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/Schedule.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/Schedule.kt
@@ -10,6 +10,7 @@ data class Schedule(
     val id: String = "",
     val title: String = "",
     val memo: String = "",
+    val familyId: String = "",
     val startDate: Timestamp = Timestamp.now(),
     val endDate: Timestamp = Timestamp.now(),
     val petNames: List<String> = emptyList(),

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/TodoModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/TodoModel.kt
@@ -2,12 +2,12 @@ package com.example.howsu.data.model
 
 import androidx.annotation.DrawableRes
 import com.google.firebase.firestore.DocumentId
-import java.util.UUID
 
 data class Task(
-    val id: String = UUID.randomUUID().toString(),
+    val id: String = "", // <-- Firestore가 DB 값을 채워넣을 수 있도록 빈 값으로 변경
     val title: String? = null,
     val date: String? = null,
+    @JvmField
     val isChecked: Boolean = false
 )
 

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/TodoModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/TodoModel.kt
@@ -14,9 +14,9 @@ data class Task(
 data class TodoGroup(
     @DocumentId
     val documentId: String = "",
-
     val assigneeId: String? = null,
     val assigneeName: String? = null,
+    val familyId: String = "", // ★ 추가: 가족 공유를 위한 핵심 키
     @DrawableRes val assigneeProfileRes: Int? = null,
     val tasks: List<Task> = emptyList(),
     val petNames: List<String> = emptyList()

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/TodoModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/TodoModel.kt
@@ -1,17 +1,23 @@
 package com.example.howsu.data.model
 
 import androidx.annotation.DrawableRes
+import com.google.firebase.firestore.DocumentId
+import java.util.UUID
 
 data class Task(
-    var id: Int = 0,
-    var title: String = "",
-    var date: String = "",
-    var isChecked: Boolean = false
+    val id: String = UUID.randomUUID().toString(),
+    val title: String? = null,
+    val date: String? = null,
+    val isChecked: Boolean = false
 )
 
 data class TodoGroup(
-    var id: Int = 0,
-    var assigneeName: String = "",
-    @DrawableRes var assigneeProfileRes: Int? = null,
-    var tasks: List<Task> = emptyList()
+    @DocumentId
+    val documentId: String = "",
+
+    val assigneeId: String? = null,
+    val assigneeName: String? = null,
+    @DrawableRes val assigneeProfileRes: Int? = null,
+    val tasks: List<Task> = emptyList(),
+    val petNames: List<String> = emptyList()
 )

--- a/Howsu/app/src/main/java/com/example/howsu/data/model/User.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/data/model/User.kt
@@ -1,0 +1,9 @@
+package com.example.howsu.data.model
+
+data class User(
+    val uid: String,            // Firebase Auth UID (로그인 고유 키)
+    val email: String?,         // 이메일
+    val name: String,           // 가입 시 사용자 이름
+    val currentFamilyId: String?, // 현재 보고 있는 가족 방 ID (없으면 null)
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
@@ -20,6 +20,7 @@ import com.example.howsu.screen.login.LoginScreen
 import com.example.howsu.screen.schedule.CreateScheduleScreen
 import com.example.howsu.screen.schedule.ScheduleDetailScreen
 import com.example.howsu.screen.schedule.ScheduleScreen
+import com.example.howsu.screen.setting.SettingScreen
 import com.example.howsu.screen.todo.CreateTodoScreen
 import com.example.howsu.screen.todo.TodoScreen
 
@@ -67,6 +68,11 @@ fun AppNavigation() {
                     authViewModel = authViewModel
                 )
             }
+        }
+
+        // 세팅 화면 추가 (테스트)
+        composable(route = "profile") {
+            SettingScreen(navController = navController)
         }
 
         // home화면 추가

--- a/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
@@ -10,25 +10,25 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.example.howsu.Pet.PetRegisterViewModel
+import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.screen.feed.FeedHomeScreen
 import com.example.howsu.screen.feed.FeedViewModel
 import com.example.howsu.screen.feed.FeedWriteScreen
-import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.screen.home.HomeScreen
+import com.example.howsu.screen.home.Pet
 import com.example.howsu.screen.home.PetDetailScreen
 import com.example.howsu.screen.login.AuthViewModel
 import com.example.howsu.screen.login.JoinScreen
 import com.example.howsu.screen.login.LoadingScreen
 import com.example.howsu.screen.login.LoginScreen
+import com.example.howsu.screen.pet.PetRegisterCompleteScreen
+import com.example.howsu.screen.pet.PetRegisterScreen
 import com.example.howsu.screen.schedule.CreateScheduleScreen
 import com.example.howsu.screen.schedule.ScheduleDetailScreen
 import com.example.howsu.screen.schedule.ScheduleScreen
 import com.example.howsu.screen.setting.SettingScreen
 import com.example.howsu.screen.todo.CreateTodoScreen
 import com.example.howsu.screen.todo.TodoScreen
-import com.example.howsu.screen.home.Pet
-import com.example.howsu.screen.pet.PetRegisterCompleteScreen
-import com.example.howsu.screen.pet.PetRegisterScreen
 
 // (TODO: 다른 화면들도 Import)
 
@@ -51,7 +51,7 @@ fun AppNavigation() {
     // 5. NavHost가 화면을 관리
     NavHost(
         navController = navController,
-        startDestination = "register_pet" // ★ 앱 시작 시 보여줄 첫 화면
+        startDestination = "loading" // ★ 앱 시작 시 보여줄 첫 화면
     ) {
         composable(route = "loading") {
             LoadingScreen(navController = navController)

--- a/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
@@ -1,11 +1,15 @@
 package com.example.howsu.navigation // (1. 새 패키지 이름)
 
+import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import com.example.howsu.Pet.PetRegisterViewModel
 import com.example.howsu.screen.feed.FeedHomeScreen
 import com.example.howsu.screen.feed.FeedViewModel
 import com.example.howsu.screen.feed.FeedWriteScreen
@@ -22,9 +26,12 @@ import com.example.howsu.screen.schedule.ScheduleScreen
 import com.example.howsu.screen.todo.CreateTodoScreen
 import com.example.howsu.screen.todo.TodoScreen
 import com.example.howsu.screen.home.Pet
+import com.example.howsu.screen.pet.PetRegisterCompleteScreen
+import com.example.howsu.screen.pet.PetRegisterScreen
 
 // (TODO: 다른 화면들도 Import)
 
+@SuppressLint("ViewModelConstructorInComposable")
 @Composable
 fun AppNavigation() {
     // 4. 내비게이션 컨트롤러 생성
@@ -38,11 +45,12 @@ fun AppNavigation() {
     )
 
     val feedViewModel: FeedViewModel = viewModel()
+    val petRegisterViewModel : PetRegisterViewModel = viewModel()
 
     // 5. NavHost가 화면을 관리
     NavHost(
         navController = navController,
-        startDestination = "loading" // ★ 앱 시작 시 보여줄 첫 화면
+        startDestination = "register_pet" // ★ 앱 시작 시 보여줄 첫 화면
     ) {
         composable(route = "loading") {
             LoadingScreen(navController = navController)
@@ -160,6 +168,32 @@ fun AppNavigation() {
                     editPost = post
                 )
             }
+        }
+
+        //닉네임 등록 및 반려동물 등록 화면
+        composable(route = "register_pet") {
+            PetRegisterScreen(viewModel = petRegisterViewModel,navController = navController)
+        }
+
+        // 반려동물 등록 완료 화면
+        composable("pet_register_complete") {
+            val vm = PetRegisterViewModel() // 위와 같은 인스턴스를 공유해야 함
+            val uiState by vm.uiState.collectAsState()
+
+            PetRegisterCompleteScreen(
+                uiState = uiState,
+                onAddMore = {
+                    vm.resetForNewPet()
+                    navController.navigate("pet_register") {
+                        popUpTo("pet_register_complete") { inclusive = true }
+                    }
+                },
+                onFinish = {
+                    navController.navigate("home") {
+                        popUpTo("home") { inclusive = true }
+                    }
+                }
+            )
         }
     }
 

--- a/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
@@ -1,16 +1,22 @@
-package com.example.howsu.navigation // (1. 새 패키지 이름)
+package com.example.howsu.navigation
 
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.example.howsu.Pet.PetRegisterViewModel
 import com.example.howsu.data.model.FamilyMember
+import com.example.howsu.screen.family.FamilyInviteScreen
+import com.example.howsu.screen.family.FamilyRegisterIntroScreen
+import com.example.howsu.screen.famliy.FamilyJoinCompleteScreen
+import com.example.howsu.screen.famliy.NicknameRegisterScreen
 import com.example.howsu.screen.feed.FeedHomeScreen
 import com.example.howsu.screen.feed.FeedViewModel
 import com.example.howsu.screen.feed.FeedWriteScreen
@@ -29,8 +35,8 @@ import com.example.howsu.screen.schedule.ScheduleScreen
 import com.example.howsu.screen.setting.SettingScreen
 import com.example.howsu.screen.todo.CreateTodoScreen
 import com.example.howsu.screen.todo.TodoScreen
-
-// (TODO: 다른 화면들도 Import)
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 @SuppressLint("ViewModelConstructorInComposable")
 @Composable
@@ -38,52 +44,123 @@ fun AppNavigation() {
     // 4. 내비게이션 컨트롤러 생성
     val navController = rememberNavController()
 
+    // 임시 데이터
     val member = FamilyMember(
         userId = "user123",
-        relationship = "언니",              // 혹은 "엄마", "아빠" 같은 값
-        profileImageUrl = "\"C:\\KakaoTalk_20251030_100121311.jpg\"",            // 일단 프로필 없다고 가정, 있으면 URL
+        familyId = "test_family", // FamilyMember 모델 변경에 따라 추가
+        relationship = "언니",
+        profileImageUrl = null,
         nickName = "이구역의짱"
     )
 
+    // ★ 상위 레벨에서 ViewModel 생성 (화면 간 데이터 공유를 위해)
     val feedViewModel: FeedViewModel = viewModel()
     val petRegisterViewModel : PetRegisterViewModel = viewModel()
 
     // 5. NavHost가 화면을 관리
     NavHost(
         navController = navController,
-        startDestination = "loading" // ★ 앱 시작 시 보여줄 첫 화면
+        startDestination = "loading"
     ) {
         composable(route = "loading") {
             LoadingScreen(navController = navController)
         }
 
         navigation(startDestination = "login", route = "auth_graph") {
-
-            // "login" Composable 안에 ViewModel 생성
             composable(route = "login") {
                 val authViewModel: AuthViewModel = viewModel()
-                LoginScreen(
-                    navController = navController,
-                    authViewModel = authViewModel
-                )
+                LoginScreen(navController = navController, authViewModel = authViewModel)
             }
-
-            // "join" Composable 안에 ViewModel 생성
             composable(route = "join") {
                 val authViewModel: AuthViewModel = viewModel()
-                JoinScreen(
-                    navController = navController,
-                    authViewModel = authViewModel
-                )
+                JoinScreen(navController = navController, authViewModel = authViewModel)
             }
         }
 
-        // 세팅 화면 추가 (테스트)
         composable(route = "profile") {
             SettingScreen(navController = navController)
         }
 
-        // home화면 추가
+        // 1. 닉네임 등록
+        composable(route = "register_nickname") {
+            NicknameRegisterScreen(
+                navController = navController,
+                onNicknameComplete = { nickname, profileUrl ->
+                    // URL 인코딩 처리
+                    val route = if (profileUrl != null) {
+                        val encodedUrl = URLEncoder.encode(profileUrl, StandardCharsets.UTF_8.toString())
+                        "family_register_intro/$nickname?profileUrl=$encodedUrl"
+                    } else {
+                        "family_register_intro/$nickname"
+                    }
+                    navController.navigate(route)
+                }
+            )
+        }
+
+        // 2. 가족 등록 인트로 (가족 생성/참여 분기점)
+        composable(
+            route = "family_register_intro/{nickname}?profileUrl={profileUrl}",
+            arguments = listOf(
+                navArgument("nickname") { type = NavType.StringType },
+                navArgument("profileUrl") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
+        ) { backStackEntry ->
+            val nickname = backStackEntry.arguments?.getString("nickname") ?: "사용자"
+            val finalProfileUrl = backStackEntry.arguments?.getString("profileUrl")
+
+            FamilyRegisterIntroScreen(
+                navController = navController,
+                userNickname = nickname,
+                userProfileUrl = finalProfileUrl
+            )
+        }
+
+        // 3. 가족 초대 (QR 코드 화면)
+        composable(
+            // ★ 이름과 ID를 모두 받도록 수정 완료됨
+            route = "family_invite_screen/{familyName}/{familyId}",
+            arguments = listOf(
+                navArgument("familyName") { type = NavType.StringType },
+                navArgument("familyId") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val familyName = backStackEntry.arguments?.getString("familyName") ?: ""
+            val familyId = backStackEntry.arguments?.getString("familyId") ?: ""
+
+            FamilyInviteScreen(
+                navController = navController,
+                familyNameInput = familyName,
+                invitedFamilyId = familyId // 전달받은 ID 주입
+            )
+        }
+
+        composable(
+            // 가족 이름과 사용자 프로필 URL을 인자로 받음
+            route = "family_join_complete/{familyName}?profileUrl={profileUrl}",
+            arguments = listOf(
+                navArgument("familyName") { type = NavType.StringType },
+                navArgument("profileUrl") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            )
+        ) { backStackEntry ->
+            val familyName = backStackEntry.arguments?.getString("familyName") ?: "우리"
+            val profileUrl = backStackEntry.arguments?.getString("profileUrl")
+
+            FamilyJoinCompleteScreen(
+                navController = navController,
+                familyName = familyName,
+                encodedProfileUrl = profileUrl
+            )
+        }
+
         composable(route = "home") {
             HomeScreen(navController = navController)
         }
@@ -111,85 +188,61 @@ fun AppNavigation() {
         composable(route = "create_todo") {
             CreateTodoScreen(navController = navController)
         }
-
         composable(route = "edit_todo/{documentId}") { backStackEntry ->
-            // 1. documentId를 가져옴
             val documentId = backStackEntry.arguments?.getString("documentId")
-
-            // 2. CreateTodoScreen에 documentId 전달
-            CreateTodoScreen(
-                navController = navController,
-                documentId = documentId
-            )
+            CreateTodoScreen(navController = navController, documentId = documentId)
         }
 
-        // ★ 펫 상세 정보 화면 추가 (petId를 인자로 받음)
-        composable(
-            route = "pet_detail/{petId}" // 경로 정의
-        ) { backStackEntry ->
-            val petId = backStackEntry.arguments?.getString("petId")
-
-            // 현재는 PetDetailScreen이 Pet 객체를 직접 받으므로, 임시 Pet 객체를 전달함
-            // 실제 앱에서는 petId를 이용해 ViewModel에서 Pet 객체를 가져옴
-
-            // 임시 Pet 객체 생성 (나중에 petId를 이용한 데이터 로드 로직으로 대체)
-            val dummyPet = Pet(
-                name = "자몽", // 실제로는 ID를 통해 이름 로드
-                age = 7,
-                gender = "여아"
-            )
-
-            // PetDetailScreen 호출
-            PetDetailScreen(
-                navController = navController,
-                pet = dummyPet // TODO: 실제 Pet 객체로 대체 필요
-            )
+        // 펫 상세
+        composable(route = "pet_detail/{petId}") { backStackEntry ->
+            val dummyPet = Pet(name = "자몽", age = 7, gender = "여아")
+            PetDetailScreen(navController = navController, pet = dummyPet)
         }
 
+        // --- (피드) ---
         composable(route = "feed") {
             FeedHomeScreen(navController = navController, viewModel = feedViewModel, member = member)
         }
-
         composable(route = "create_feed") {
-            FeedWriteScreen(
-                viewModel = feedViewModel,
-                onFinishWrite = { navController.popBackStack() }
-            )
+            FeedWriteScreen(viewModel = feedViewModel, onFinishWrite = { navController.popBackStack() })
         }
-
-        // ★ 피드 수정 화면
         composable("edit_feed/{postId}") { backStackEntry ->
             val postId = backStackEntry.arguments?.getString("postId")?.toLongOrNull()
             val post = feedViewModel.posts.find { it.id == postId }
-
             if (post != null) {
-                FeedWriteScreen(
-                    viewModel = feedViewModel,
-                    onFinishWrite = { navController.popBackStack() },
-                    editPost = post
-                )
+                FeedWriteScreen(viewModel = feedViewModel, onFinishWrite = { navController.popBackStack() }, editPost = post)
             }
         }
 
-        //닉네임 등록 및 반려동물 등록 화면
+        // --- (반려동물 등록) ---
+
+        // 1. 정보 입력 화면
         composable(route = "register_pet") {
-            PetRegisterScreen(viewModel = petRegisterViewModel,navController = navController)
+            // 상단에서 생성한 petRegisterViewModel 인스턴스 사용
+            PetRegisterScreen(
+                viewModel = petRegisterViewModel,
+                navController = navController
+            )
         }
 
-        // 반려동물 등록 완료 화면
+        // 2. 등록 완료 화면
         composable("pet_register_complete") {
-            val vm = PetRegisterViewModel() // 위와 같은 인스턴스를 공유해야 함
+            // ★ [중요 수정] 여기서 'PetRegisterViewModel()'로 새로 만들면 안 됩니다!
+            // 위에서 만든 'petRegisterViewModel'을 재사용해야 데이터가 유지됩니다.
+            val vm = petRegisterViewModel
             val uiState by vm.uiState.collectAsState()
 
             PetRegisterCompleteScreen(
                 uiState = uiState,
                 onAddMore = {
                     vm.resetForNewPet()
-                    navController.navigate("pet_register") {
+                    // 등록 화면으로 돌아가되, 완료 화면은 스택에서 제거
+                    navController.navigate("register_pet") {
                         popUpTo("pet_register_complete") { inclusive = true }
                     }
                 },
                 onFinish = {
+                    // 홈으로 이동하며 백스택 정리
                     navController.navigate("home") {
                         popUpTo("home") { inclusive = true }
                     }
@@ -197,5 +250,4 @@ fun AppNavigation() {
             )
         }
     }
-
 }

--- a/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/navigation/AppNavigation.kt
@@ -6,11 +6,12 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.screen.feed.FeedHomeScreen
 import com.example.howsu.screen.feed.FeedViewModel
 import com.example.howsu.screen.feed.FeedWriteScreen
-import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.screen.home.HomeScreen
+import com.example.howsu.screen.home.Pet
 import com.example.howsu.screen.home.PetDetailScreen
 import com.example.howsu.screen.login.AuthViewModel
 import com.example.howsu.screen.login.JoinScreen
@@ -21,7 +22,6 @@ import com.example.howsu.screen.schedule.ScheduleDetailScreen
 import com.example.howsu.screen.schedule.ScheduleScreen
 import com.example.howsu.screen.todo.CreateTodoScreen
 import com.example.howsu.screen.todo.TodoScreen
-import com.example.howsu.screen.home.Pet
 
 // (TODO: 다른 화면들도 Import)
 
@@ -74,43 +74,38 @@ fun AppNavigation() {
             HomeScreen(navController = navController)
         }
 
-        // TODO: 나중에 "home" 또는 "schedule" 경로도 여기에 추가
+        // --- (스케줄) ---
         composable(route = "schedule") {
             ScheduleScreen(navController = navController)
         }
-
         composable(route = "create_schedule") {
             CreateScheduleScreen(navController = navController)
         }
+        composable(route = "schedule_detail/{scheduleId}") { backStackEntry ->
+            val scheduleId = backStackEntry.arguments?.getString("scheduleId")
+            ScheduleDetailScreen(navController = navController, scheduleId = scheduleId)
+        }
+        composable(route = "edit_schedule/{scheduleId}") { backStackEntry ->
+            val scheduleId = backStackEntry.arguments?.getString("scheduleId")
+            CreateScheduleScreen(navController = navController, scheduleId = scheduleId)
+        }
 
+        // --- (투두) ---
         composable(route = "todo") {
             TodoScreen(navController = navController)
         }
-
         composable(route = "create_todo") {
             CreateTodoScreen(navController = navController)
         }
 
-        composable(
-            route = "schedule_detail/{scheduleId}"
-        ) { backStackEntry ->
-            // URL 경로에서 scheduleId를 꺼냅니다.
-            val scheduleId = backStackEntry.arguments?.getString("scheduleId")
-            ScheduleDetailScreen(
-                navController = navController,
-                scheduleId = scheduleId
-            )
-        }
+        composable(route = "edit_todo/{documentId}") { backStackEntry ->
+            // 1. documentId를 가져옴
+            val documentId = backStackEntry.arguments?.getString("documentId")
 
-        // ★ 3. (신규) 일정 수정 화면
-        composable(
-            route = "edit_schedule/{scheduleId}"
-        ) { backStackEntry ->
-            val scheduleId = backStackEntry.arguments?.getString("scheduleId")
-
-            CreateScheduleScreen(
+            // 2. CreateTodoScreen에 documentId 전달
+            CreateTodoScreen(
                 navController = navController,
-                scheduleId = scheduleId // ★ 1. scheduleId를 여기에 전달
+                documentId = documentId
             )
         }
 

--- a/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyInviteScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyInviteScreen.kt
@@ -1,0 +1,259 @@
+package com.example.howsu.screen.family
+
+import android.widget.Toast
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+
+// ★ 삭제됨: FamilyInviteViewModel (이제 필요 없음)
+
+@Composable
+fun FamilyInviteScreen(
+    navController: NavHostController,
+    familyNameInput: String,
+    invitedFamilyId: String, // ★ 핵심: 이전 화면에서 생성해서 넘겨준 진짜 ID
+    userProfileUrl: String? = null
+) {
+    // 1. 한글 받침 처리
+    val displayName = getFamilyNameWithSuffix(familyNameInput)
+
+    // ★ 수정됨: ViewModel이나 random 생성 없이, 넘겨받은 invitedFamilyId를 바로 사용합니다.
+
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            InviteTopBar(onBack = { navController.popBackStack() })
+        },
+        bottomBar = {
+            InviteBottomBar(
+                onComplete = {
+                    // 완료 시 반려동물 등록 화면 등으로 이동
+                    navController.navigate("register_pet") // 경로 이름 주의 ("pet_register_screen" -> "register_pet")
+                }
+            )
+        },
+        containerColor = Color.White
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // --- QR 카드 영역 ---
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                // 1. 카드 배경
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 40.dp),
+                    shape = RoundedCornerShape(20.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFF5F5F5))
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 50.dp, bottom = 40.dp, start = 24.dp, end = 26.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        // 가족 이름
+                        Text(
+                            text = displayName,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 18.sp,
+                            color = Color.Black
+                        )
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        // QR 코드 이미지
+                        QrCodePlaceholder(modifier = Modifier.size(180.dp))
+                    }
+                }
+
+                // 2. 겹쳐지는 프로필 사진
+                ProfileImageCircle(
+                    imageUrl = userProfileUrl,
+                    modifier = Modifier.size(80.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+            // --- "또는" 구분선 ---
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                HorizontalDivider(modifier = Modifier.weight(1f), color = Color(0xFFEEEEEE))
+                Text(
+                    text = "또는",
+                    color = Color(0xFFBDBDBD),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(horizontal = 12.dp)
+                )
+                HorizontalDivider(modifier = Modifier.weight(1f), color = Color(0xFFEEEEEE))
+            }
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+            // --- 아이디 복사 섹션 ---
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .border(1.dp, Color(0xFFF5F5F5), RoundedCornerShape(12.dp))
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable {
+                        // ★ 수정됨: invitedFamilyId를 복사
+                        clipboardManager.setText(AnnotatedString(invitedFamilyId))
+                        Toast.makeText(context, "아이디가 복사되었습니다", Toast.LENGTH_SHORT).show()
+                    }
+                    .background(Color.White)
+                    .padding(horizontal = 20.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "아이디 복사하기",
+                        color = Color(0xFF757575),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        // ★ 수정됨: 넘겨받은 ID 표시
+                        text = invitedFamilyId,
+                        color = Color.Black,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+// --- 로직 함수 ---
+fun getFamilyNameWithSuffix(name: String): String {
+    if (name.isBlank()) return "우리 가족"
+    val lastChar = name.last()
+    if (lastChar < '가' || lastChar > '힣') return "${name}네 가족"
+    val hasBatchim = (lastChar.code - 0xAC00) % 28 > 0
+    return if (hasBatchim) "${name}이네 가족" else "${name}네 가족"
+}
+
+// --- UI 컴포넌트 (변경 없음) ---
+@Composable
+fun InviteTopBar(onBack: () -> Unit) {
+    Box(modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 16.dp, vertical = 12.dp).height(40.dp)) {
+        Text("가족 초대하기", fontWeight = FontWeight.Bold, fontSize = 18.sp, modifier = Modifier.align(Alignment.Center))
+        IconButton(onClick = onBack, modifier = Modifier.size(39.dp).align(Alignment.CenterStart)) {
+            Icon(Icons.Default.ArrowBack, "뒤로 가기", modifier = Modifier.size(24.dp))
+        }
+    }
+}
+
+@Composable
+fun InviteBottomBar(onComplete: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().background(Color.Transparent).padding(start = 24.dp, end = 24.dp, top = 16.dp, bottom = 60.dp)) {
+        Button(
+            onClick = onComplete, modifier = Modifier.fillMaxWidth().height(56.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Black, contentColor = Color.White),
+            shape = RoundedCornerShape(12.dp), enabled = true
+        ) { Text("완료하기", fontWeight = FontWeight.Bold, fontSize = 16.sp) }
+    }
+}
+
+@Composable
+fun ProfileImageCircle(imageUrl: String?, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.clip(CircleShape).background(Color(0xFFEBEBEB)).border(4.dp, Color.White, CircleShape), contentAlignment = Alignment.Center) {
+        if (!imageUrl.isNullOrBlank()) { AsyncImage(model = imageUrl, contentDescription = null, contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize()) }
+    }
+}
+
+@Composable
+fun QrCodePlaceholder(modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier) {
+        val pixelSize = size.width / 25
+        drawRect(color = Color.Black, size = Size(pixelSize * 7, pixelSize * 7), topLeft = Offset(0f, 0f))
+        drawRect(color = Color.Black, size = Size(pixelSize * 7, pixelSize * 7), topLeft = Offset(size.width - pixelSize * 7, 0f))
+        drawRect(color = Color.Black, size = Size(pixelSize * 7, pixelSize * 7), topLeft = Offset(0f, size.height - pixelSize * 7))
+        for (i in 0..200) {
+            val x = (0..24).random() * pixelSize
+            val y = (0..24).random() * pixelSize
+            drawRect(color = Color.Black, topLeft = Offset(x, y), size = Size(pixelSize * 0.8f, pixelSize * 0.8f))
+        }
+    }
+}
+
+// ★ Preview 수정: invitedFamilyId 파라미터 추가
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun FamilyInvitePreview() {
+    val navController = rememberNavController()
+    FamilyInviteScreen(navController, familyNameInput = "자몽", invitedFamilyId = "sda@1234")
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun FamilyInvitePreviewNoBatchim() {
+    val navController = rememberNavController()
+    FamilyInviteScreen(navController, familyNameInput = "루비", invitedFamilyId = "test@5678")
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyJoinCompleteScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyJoinCompleteScreen.kt
@@ -1,0 +1,124 @@
+package com.example.howsu.screen.famliy
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.howsu.screen.family.DisplayDoubleRingProfile
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+// --- [신규] 가족 참여 완료 화면 ---
+@Composable
+fun FamilyJoinCompleteScreen(
+    navController: NavHostController,
+    familyName: String,
+    encodedProfileUrl: String?
+) {
+    // URL 디코딩 (null 문자열 처리 포함)
+    val decodedProfileUrl = remember(encodedProfileUrl) {
+        if (encodedProfileUrl != null && encodedProfileUrl != "null") {
+            URLDecoder.decode(encodedProfileUrl, StandardCharsets.UTF_8.toString())
+        } else {
+            null
+        }
+    }
+
+    Scaffold(
+        bottomBar = {
+            // "시작하기" 버튼
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)
+                    .padding(bottom = 36.dp) // 하단 여백 추가
+            ) {
+                Button(
+                    onClick = {
+                        // 홈 화면으로 이동하며 백스택 정리
+                        navController.navigate("home") {
+                            popUpTo("home") { inclusive = true }
+                        }
+                        // 또는 펫 등록이 필요하면 "register_pet"으로 이동
+                        // navController.navigate("register_pet") { popUpTo("register_pet") { inclusive = true } }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.Black,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Text("시작하기", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                }
+            }
+        },
+        containerColor = Color.White
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center // 중앙 정렬
+        ) {
+            // 가족 이름 표시
+            Text(
+                text = "$familyName 가족",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.Black
+            )
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // 사용자 프로필 + 애니메이션 (기존 컴포저블 재사용)
+            DisplayDoubleRingProfile(imageUrl = decodedProfileUrl)
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            // 참여 완료 메시지
+            Text(
+                text = "참여 완료!",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun FamilyJoinCompleteScreenPreview() {
+    val navController = rememberNavController()
+
+    FamilyJoinCompleteScreen(
+        navController = navController,
+        familyName = "루비네",
+        encodedProfileUrl = null // 프로필 이미지가 없는 경우 테스트
+    )
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyRegisterIntroScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyRegisterIntroScreen.kt
@@ -1,0 +1,410 @@
+package com.example.howsu.screen.family
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+// -------------------------------------------------------------------
+// 메인 화면 (로직 및 내비게이션 처리)
+// -------------------------------------------------------------------
+@Composable
+fun FamilyRegisterIntroScreen(
+    navController: NavHostController,
+    userNickname: String = "이구역의짱",
+    userProfileUrl: String? = null,
+    viewModel: FamilyRegisterViewModel = viewModel()
+) {
+    // ViewModel 상태 사용
+    val regState = viewModel.regState
+    val selectedTab = viewModel.selectedTab
+
+    // 버튼 활성화 로직
+    val isNextEnabled = when (regState) {
+        FamilyRegState.NONE -> false
+        FamilyRegState.SKIP -> true
+        FamilyRegState.PRE_DO_IT -> true
+        FamilyRegState.DO_IT -> {
+            when (selectedTab) {
+                FamilyTab.CREATE -> viewModel.inputFamilyName.isNotBlank()
+                FamilyTab.JOIN -> viewModel.inputFamilyId.isNotBlank()
+            }
+        }
+    }
+
+    // [공통] 참여 로직 함수 (검색 버튼 & 계속하기 버튼에서 같이 사용)
+    val handleJoin = {
+        if (viewModel.joinFamily()) {
+            // 1. 참여한 가족 이름 (실제로는 DB에서 가져온 값이어야 함)
+            val joinedFamilyName = "루비네" // 임시 값
+
+            // 2. 프로필 URL 인코딩 (URL 파라미터로 넘기기 위해 필수)
+            val encodedUrl = if (userProfileUrl != null) {
+                URLEncoder.encode(userProfileUrl, StandardCharsets.UTF_8.toString())
+            } else {
+                "null"
+            }
+
+            // 3. 참여 완료 화면으로 이동
+            navController.navigate("family_join_complete/$joinedFamilyName?profileUrl=$encodedUrl")
+        }
+    }
+
+    FamilyRegisterContent(
+        userNickname = userNickname,
+        userProfileUrl = userProfileUrl,
+        regState = regState,
+        selectedTab = selectedTab,
+        // ViewModel 변수 연결
+        familyName = viewModel.inputFamilyName,
+        familyId = viewModel.inputFamilyId,
+        isNextEnabled = isNextEnabled,
+
+        onBack = {
+            if (regState == FamilyRegState.DO_IT) {
+                viewModel.regState = FamilyRegState.PRE_DO_IT
+            } else {
+                navController.popBackStack()
+            }
+        },
+        // 값 변경 이벤트 연결
+        onRegStateChange = { viewModel.regState = it },
+        onTabChange = { viewModel.selectedTab = it },
+        onNameChange = { viewModel.inputFamilyName = it },
+        onIdChange = { viewModel.inputFamilyId = it },
+
+        // ★ [추가] 검색 아이콘 클릭 시 동작 연결
+        onJoinAction = { handleJoin() },
+
+        // 하단 [계속하기] 버튼 클릭 로직
+        onNext = {
+            when (regState) {
+                FamilyRegState.PRE_DO_IT -> {
+                    viewModel.regState = FamilyRegState.DO_IT
+                }
+
+                FamilyRegState.DO_IT -> {
+                    if (selectedTab == FamilyTab.CREATE) {
+                        // A. [가족 생성]
+                        viewModel.createSharedFamily()
+                        val name = viewModel.inputFamilyName
+                        val id = viewModel.createdFamilyId
+                        navController.navigate("family_invite_screen/$name/$id")
+                    } else {
+                        // B. [가족 참여] -> 공통 함수 호출
+                        handleJoin()
+                    }
+                }
+
+                FamilyRegState.SKIP -> {
+                    // C. [안 할래요] -> 1인 가족 생성
+                    viewModel.createSoloFamily(userNickname)
+                    navController.navigate("register_pet")
+                }
+
+                else -> {}
+            }
+        }
+    )
+}
+
+// -------------------------------------------------------------------
+// UI 콘텐츠
+// -------------------------------------------------------------------
+@Composable
+fun FamilyRegisterContent(
+    userNickname: String,
+    userProfileUrl: String?,
+    regState: FamilyRegState,
+    selectedTab: FamilyTab,
+    familyName: String,
+    familyId: String,
+    isNextEnabled: Boolean,
+    onBack: () -> Unit,
+    onRegStateChange: (FamilyRegState) -> Unit,
+    onTabChange: (FamilyTab) -> Unit,
+    onNameChange: (String) -> Unit,
+    onIdChange: (String) -> Unit,
+    onNext: () -> Unit,
+    // ★ [추가] 검색 버튼 클릭 콜백
+    onJoinAction: () -> Unit
+) {
+    Scaffold(
+        topBar = { FamilyRegisterTopBar(onBack = onBack) },
+        bottomBar = { FamilyRegisterBottomBar(enabled = isNextEnabled, onNext = onNext) },
+        containerColor = Color.White
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(50.dp))
+
+            // 프로필 이미지 (애니메이션 포함)
+            DisplayDoubleRingProfile(imageUrl = userProfileUrl)
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 닉네임 & 타이틀
+            Text(
+                text = "$userNickname 님!",
+                fontWeight = FontWeight.Bold,
+                fontSize = 22.sp,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = if (regState == FamilyRegState.DO_IT) "소중한 가족을 등록해 볼까요?" else "가족 등록을 하시겠습니까?",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal,
+                color = Color(0xFF616161)
+            )
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+            // 선택 영역 vs 폼 영역
+            if (regState != FamilyRegState.DO_IT) {
+                InitialSelectionButtons(
+                    currentState = regState,
+                    onSelect = onRegStateChange
+                )
+            } else {
+                FamilyFormContent(
+                    selectedTab = selectedTab,
+                    onTabChange = onTabChange,
+                    familyName = familyName,
+                    onNameChange = onNameChange,
+                    familyId = familyId,
+                    onIdChange = onIdChange,
+                    // ★ [연결] 검색 버튼 클릭 시 실행
+                    onJoinClick = onJoinAction
+                )
+            }
+        }
+    }
+}
+
+/* -----------------------------------------------------------------------
+   하위 컴포넌트들
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun InitialSelectionButtons(
+    currentState: FamilyRegState,
+    onSelect: (FamilyRegState) -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        SelectableActionBox(
+            text = "할래요",
+            isSelected = currentState == FamilyRegState.PRE_DO_IT,
+            onClick = { onSelect(FamilyRegState.PRE_DO_IT) }
+        )
+        SelectableActionBox(
+            text = "안 할래요",
+            isSelected = currentState == FamilyRegState.SKIP,
+            onClick = { onSelect(FamilyRegState.SKIP) }
+        )
+    }
+}
+
+@Composable
+fun SelectableActionBox(text: String, isSelected: Boolean, onClick: () -> Unit) {
+    val borderColor = if (isSelected) Color.Black else Color(0xFFEAEAEA)
+    val textColor = if (isSelected) Color.Black else Color(0xFFBDBDBD)
+    val borderWidth = if (isSelected) 1.5.dp else 1.dp
+
+    Box(
+        modifier = Modifier
+            .width(150.dp)
+            .height(52.dp)
+            .border(borderWidth, borderColor, RoundedCornerShape(30.dp))
+            .clip(RoundedCornerShape(30.dp))
+            .clickable { onClick() }
+            .background(Color.White),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text, fontWeight = FontWeight.Bold, color = textColor, fontSize = 16.sp)
+    }
+}
+
+@Composable
+fun FamilyFormContent(
+    selectedTab: FamilyTab,
+    onTabChange: (FamilyTab) -> Unit,
+    familyName: String,
+    onNameChange: (String) -> Unit,
+    familyId: String,
+    onIdChange: (String) -> Unit,
+    // ★ [추가] 검색 아이콘 클릭 이벤트
+    onJoinClick: () -> Unit
+) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            TabButton("생성하기", selectedTab == FamilyTab.CREATE, Modifier.weight(1f)) { onTabChange(FamilyTab.CREATE) }
+            TabButton("참여하기", selectedTab == FamilyTab.JOIN, Modifier.weight(1f)) { onTabChange(FamilyTab.JOIN) }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (selectedTab == FamilyTab.CREATE) {
+            Text(
+                text = "가족 별칭을 입력해 주세요",
+                fontSize = 16.sp, color = Color(0xFF757575), textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
+            )
+            OutlinedTextField(
+                value = familyName, onValueChange = onNameChange, modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("예) 루비", color = Color(0xFFBDBDBD)) },
+                singleLine = true, shape = RoundedCornerShape(12.dp), colors = familyInputColors(),
+                trailingIcon = { Text("가족", fontWeight = FontWeight.Bold, fontSize = 14.sp, modifier = Modifier.padding(end = 16.dp)) }
+            )
+        } else {
+            Text(
+                text = "가족 아이디를 입력해 주세요",
+                fontSize = 16.sp, color = Color(0xFF757575), textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
+            )
+            OutlinedTextField(
+                value = familyId, onValueChange = onIdChange, modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("아이디로 참여하기", color = Color(0xFFBDBDBD)) },
+                singleLine = true, shape = RoundedCornerShape(12.dp), colors = familyInputColors(),
+                trailingIcon = {
+                    // ★ [수정] 검색 아이콘 클릭 시 onJoinClick 실행
+                    IconButton(
+                        onClick = {
+                            if (familyId.isNotBlank()) {
+                                onJoinClick()
+                            }
+                        }
+                    ) {
+                        Icon(Icons.Default.Search, "검색", tint = Color.Black, modifier = Modifier.padding(end = 8.dp))
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun TabButton(text: String, isSelected: Boolean, modifier: Modifier, onClick: () -> Unit) {
+    val containerColor = if (isSelected) Color.White else Color(0xFFFAFAFA)
+    val borderColor = if (isSelected) Color.Black else Color(0xFFEEEEEE)
+    val contentColor = if (isSelected) Color.Black else Color(0xFFBDBDBD)
+    Button(
+        onClick = onClick, modifier = modifier.height(52.dp), shape = RoundedCornerShape(26.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = containerColor, contentColor = contentColor),
+        border = androidx.compose.foundation.BorderStroke(1.5.dp, borderColor), elevation = null
+    ) { Text(text, fontWeight = FontWeight.Bold, fontSize = 16.sp) }
+}
+
+@Composable
+fun familyInputColors() = OutlinedTextFieldDefaults.colors(
+    focusedContainerColor = Color.White, unfocusedContainerColor = Color.White,
+    focusedBorderColor = Color.Black, unfocusedBorderColor = Color(0xFFE0E0E0), cursorColor = Color.Black
+)
+
+@Composable
+fun FamilyRegisterTopBar(onBack: () -> Unit) {
+    Box(modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 16.dp, vertical = 12.dp).height(40.dp)) {
+        Text("가족 등록하기", fontWeight = FontWeight.Bold, fontSize = 18.sp, modifier = Modifier.align(Alignment.Center))
+        IconButton(onClick = onBack, modifier = Modifier.size(39.dp).align(Alignment.CenterStart)) {
+            Icon(Icons.Default.ArrowBack, "뒤로 가기", modifier = Modifier.size(24.dp))
+        }
+    }
+}
+
+@Composable
+fun FamilyRegisterBottomBar(enabled: Boolean, onNext: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().background(Color.Transparent).padding(start = 24.dp, end = 24.dp, top = 16.dp, bottom = 60.dp)) {
+        Button(
+            onClick = onNext, modifier = Modifier.fillMaxWidth().height(64.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (enabled) Color.Black else Color(0xFFD6D6D6),
+                contentColor = Color.White,
+                disabledContainerColor = Color(0xFFD6D6D6), disabledContentColor = Color.White
+            ), shape = RoundedCornerShape(12.dp), enabled = enabled
+        ) { Text("계속하기", fontWeight = FontWeight.Bold, fontSize = 16.sp) }
+    }
+}
+
+@Composable
+fun DisplayDoubleRingProfile(imageUrl: String?) {
+    val infiniteTransition = rememberInfiniteTransition(label = "profilePulse")
+    val pulseScale by infiniteTransition.animateFloat(
+        initialValue = 1f, targetValue = 1.05f,
+        animationSpec = infiniteRepeatable(tween(1000, easing = FastOutSlowInEasing), RepeatMode.Reverse), label = "scale"
+    )
+    Box(modifier = Modifier.size(200.dp), contentAlignment = Alignment.Center) {
+        Box(modifier = Modifier.size(200.dp).scale(pulseScale).border(1.dp, Color(0xFFF5F5F5), CircleShape))
+        Box(modifier = Modifier.size(160.dp).scale(pulseScale).border(1.dp, Color(0xFFF5F5F5), CircleShape))
+        Box(modifier = Modifier.size(120.dp).clip(CircleShape).background(Color(0xFFEBEBEB)), contentAlignment = Alignment.Center) {
+            if (!imageUrl.isNullOrBlank()) { AsyncImage(model = imageUrl, contentDescription = null, contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize()) }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun PreviewFamilyRegister() {
+    val navController = rememberNavController()
+    FamilyRegisterIntroScreen(navController = navController)
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyRegisterViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/famliy/FamilyRegisterViewModel.kt
@@ -1,0 +1,57 @@
+package com.example.howsu.screen.family
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import kotlin.random.Random
+
+// 상태 Enum
+enum class FamilyRegState { NONE, SKIP, PRE_DO_IT, DO_IT }
+enum class FamilyTab { CREATE, JOIN }
+
+class FamilyRegisterViewModel : ViewModel() {
+    // UI 상태 관리
+    var regState by mutableStateOf(FamilyRegState.NONE)
+    var selectedTab by mutableStateOf(FamilyTab.CREATE)
+
+    // 입력 필드
+    var inputFamilyName by mutableStateOf("") // 생성할 가족 이름
+    var inputFamilyId by mutableStateOf("")   // 참여할 가족 ID
+
+    // 결과 저장용 (생성된 가족 ID)
+    var createdFamilyId by mutableStateOf("")
+
+    // [로직 1] 공유 가족 생성 (Create Shared Family)
+    fun createSharedFamily() {
+        val newId = generateRandomId()
+        createdFamilyId = newId
+        // 이름이 없으면 기본값
+        if (inputFamilyName.isBlank()) inputFamilyName = "우리 가족"
+        println("공유 가족 생성: $inputFamilyName, ID: $newId")
+    }
+
+    // [로직 2] 1인 가족 생성 (Create Solo Family)
+    // ★ nickname을 받아서 자동 작명
+    fun createSoloFamily(nickname: String) {
+        val newId = generateRandomId()
+        createdFamilyId = newId
+
+        // 이름이 없으면 "OOO님의 집"으로 자동 설정
+        if (inputFamilyName.isBlank()) {
+            inputFamilyName = "${nickname}님의 집"
+        }
+        println("1인 가족 생성: ID: $newId, 이름: $inputFamilyName")
+    }
+
+    // [로직 3] 가족 참여 (Join Family)
+    fun joinFamily(): Boolean {
+        if (inputFamilyId.isBlank()) return false
+        println("가족 참여 시도: $inputFamilyId")
+        return true
+    }
+
+    private fun generateRandomId(): String {
+        return "with@${Random.nextInt(1000, 9999)}"
+    }
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/famliy/NicknameRegisterScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/famliy/NicknameRegisterScreen.kt
@@ -1,0 +1,254 @@
+package com.example.howsu.screen.famliy
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+@Composable
+fun NicknameRegisterScreen(
+    navController: NavHostController,
+    onNicknameComplete: (String, String?) -> Unit = { nick, img -> },
+    // ViewModel 주입 (기본값으로 내부 생성)
+    viewModel: NicknameRegisterViewModel = viewModel()
+) {
+    // ViewModel 상태 사용 (화면 갔다가 돌아와도 유지됨)
+    val nickname = viewModel.nickname
+    val profileImageUrl = viewModel.profileImageUrl
+
+    // 갤러리 런처
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            viewModel.profileImageUrl = uri.toString()
+        }
+    }
+
+    val isNextEnabled = nickname.isNotBlank()
+
+    Scaffold(
+        topBar = {
+            NicknameRegisterTopBar(
+                onBack = {
+                    // 뒤로가기 시 로그아웃 및 로그인 화면으로 이동
+                    Firebase.auth.signOut()
+                    navController.navigate("login") {
+                        popUpTo(0) { inclusive = true }
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            NicknameRegisterBottomBar(
+                enabled = isNextEnabled,
+                onNext = {
+                    onNicknameComplete(nickname, profileImageUrl)
+                }
+            )
+        },
+        containerColor = Color.White
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(30.dp))
+
+            // 프로필 이미지 컴포넌트
+            DoubleRingProfileImage(
+                imageUrl = profileImageUrl,
+                onClick = { imagePickerLauncher.launch("image/*") }
+            )
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+            Text(
+                text = "사용할 닉네임을 입력해 주세요",
+                fontWeight = FontWeight.Medium,
+                color = Color(0xFF424242),
+                fontSize = 16.sp
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = nickname,
+                onValueChange = { viewModel.nickname = it }, // ViewModel 값 업데이트
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(
+                        text = "닉네임 입력하기",
+                        color = Color(0xFFBDBDBD),
+                        fontSize = 14.sp
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Color.White,
+                    focusedBorderColor = Color.Black,
+                    unfocusedBorderColor = Color(0xFFE0E0E0),
+                    cursorColor = Color.Black
+                )
+            )
+        }
+    }
+}
+
+/* -----------------------------------------------------------------------
+   UI Components
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun NicknameRegisterTopBar(onBack: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .height(40.dp)
+    ) {
+        Text(
+            text = "닉네임 등록하기",
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp,
+            modifier = Modifier.align(Alignment.Center)
+        )
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier
+                .size(39.dp)
+                .align(Alignment.CenterStart)
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "뒤로 가기",
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun NicknameRegisterBottomBar(enabled: Boolean, onNext: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.Transparent)
+            .padding(start = 24.dp, end = 24.dp, top = 16.dp, bottom = 60.dp)
+    ) {
+        Button(
+            onClick = onNext,
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (enabled) Color.Black else Color(0xFFD6D6D6),
+                contentColor = Color.White,
+                disabledContainerColor = Color(0xFFD6D6D6),
+                disabledContentColor = Color.White
+            ),
+            shape = RoundedCornerShape(12.dp),
+            enabled = enabled
+        ) {
+            Text(text = "계속하기", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        }
+    }
+}
+
+@Composable
+fun DoubleRingProfileImage(imageUrl: String?, onClick: () -> Unit) {
+    val infiniteTransition = rememberInfiniteTransition(label = "profilePulse")
+    val pulseScale by infiniteTransition.animateFloat(
+        initialValue = 1f, targetValue = 1.05f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1000, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ), label = "scale"
+    )
+
+    Box(
+        modifier = Modifier
+            .size(280.dp)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Box(modifier = Modifier.size(280.dp).scale(pulseScale).border(1.dp, Color(0xFFF5F5F5), CircleShape))
+        Box(modifier = Modifier.size(220.dp).scale(pulseScale).border(1.dp, Color(0xFFF5F5F5), CircleShape))
+        Box(modifier = Modifier.size(160.dp).clip(CircleShape).background(Color(0xFFEBEBEB)), contentAlignment = Alignment.Center) {
+            if (!imageUrl.isNullOrBlank()) {
+                AsyncImage(model = imageUrl, contentDescription = "Profile Image", contentScale = ContentScale.Crop, modifier = Modifier.fillMaxSize())
+            }
+        }
+        Box(modifier = Modifier.size(160.dp)) {
+            Surface(
+                modifier = Modifier.align(Alignment.BottomEnd).offset(4.dp, 4.dp).size(40.dp),
+                shape = RoundedCornerShape(12.dp), color = Color.White, shadowElevation = 3.dp
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(Icons.Outlined.Image, "사진 변경", tint = Color.Black, modifier = Modifier.size(22.dp))
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun NicknameRegisterScreenPreview() {
+    val navController = rememberNavController()
+    NicknameRegisterScreen(navController = navController)
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/famliy/NicknameRegisterViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/famliy/NicknameRegisterViewModel.kt
@@ -1,0 +1,12 @@
+package com.example.howsu.screen.famliy
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class NicknameRegisterViewModel : ViewModel() {
+    // 화면이 전환되어도 유지되어야 할 데이터
+    var nickname by mutableStateOf("")
+    var profileImageUrl by mutableStateOf<String?>(null)
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/feed/FeedCreateScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/feed/FeedCreateScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
@@ -245,8 +246,12 @@ fun FeedWriteScreen(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                enabled = canUpload
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Black,
+                    contentColor = Color.White
+                ),
+                shape = RoundedCornerShape(12.dp)
             ) {
                 Text(if (editPost == null) "업로드하기" else "수정 완료")
             }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/feed/FeedHomeScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/feed/FeedHomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.example.howsu.common.MyBottomNavigationBar
 import com.example.howsu.common.MyFloatingActionButton
 import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.data.model.FeedFilter
@@ -98,7 +99,13 @@ fun FeedHomeScreen(
                 onFeedCreateClick = { navController.navigate("create_feed") }
             )
         }
-
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+        ) {
+            MyBottomNavigationBar(navController = navController)
+        }
 
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/login/AuthViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/login/AuthViewModel.kt
@@ -30,8 +30,19 @@ class AuthViewModel : ViewModel() {
     private val auth: FirebaseAuth = Firebase.auth
     private val functions: FirebaseFunctions = Firebase.functions("asia-northeast3")
 
+    // ★★★ ID 연동 로직 추가 ★★★
+    private val _currentUserId = MutableStateFlow<String?>(auth.currentUser?.uid)
+    val currentUserId = _currentUserId.asStateFlow()
+
     private val _loginState = MutableStateFlow<FirebaseLoginState>(FirebaseLoginState.Idle)
     val loginState = _loginState.asStateFlow()
+
+    init {
+        // Firebase 인증 상태 리스너 등록
+        auth.addAuthStateListener { firebaseAuth ->
+            _currentUserId.value = firebaseAuth.currentUser?.uid
+        }
+    }
 
     /**
      * 이메일/비밀번호로 신규 회원가입
@@ -40,14 +51,10 @@ class AuthViewModel : ViewModel() {
         _loginState.value = FirebaseLoginState.Loading
         viewModelScope.launch {
             try {
-                // Firebase SDK에 회원가입 요청
                 auth.createUserWithEmailAndPassword(email, password).await()
-
-                // 성공! (회원가입 성공 시 자동으로 로그인됩니다)
                 _loginState.value = FirebaseLoginState.Success
-
+                _currentUserId.value = auth.currentUser?.uid // ID 업데이트
             } catch (e: Exception) {
-                // 실패 (예: 이미 사용 중인 이메일, 비밀번호 형식 오류 등)
                 Log.e("AuthViewModel", "Email sign-up failed", e)
                 _loginState.value = FirebaseLoginState.Error(e.message ?: "이메일 회원가입 실패")
             }
@@ -61,60 +68,49 @@ class AuthViewModel : ViewModel() {
         _loginState.value = FirebaseLoginState.Loading
         viewModelScope.launch {
             try {
-                // Firebase SDK에 로그인 요청
                 auth.signInWithEmailAndPassword(email, password).await()
-
-                // 성공!
                 _loginState.value = FirebaseLoginState.Success
-
+                _currentUserId.value = auth.currentUser?.uid // ID 업데이트
             } catch (e: Exception) {
-                // 실패 (예: 잘못된 이메일, 틀린 비밀번호 등)
                 Log.e("AuthViewModel", "Email sign-in failed", e)
                 _loginState.value = FirebaseLoginState.Error(e.message ?: "이메일 로그인 실패")
             }
         }
     }
+
     fun signInWithGoogleCredential(credential: AuthCredential) {
         _loginState.value = FirebaseLoginState.Loading
         viewModelScope.launch {
             try {
-                // Firebase SDK에 로그인 요청
                 auth.signInWithCredential(credential).await()
-
-                // 성공!
                 _loginState.value = FirebaseLoginState.Success
-
+                _currentUserId.value = auth.currentUser?.uid // ID 업데이트
             } catch (e: Exception) {
-                // 실패
                 _loginState.value = FirebaseLoginState.Error(e.message ?: "Firebase 로그인 실패")
             }
         }
     }
 
     fun startKakaoLogin(context: Context) {
-        // 1. 카카오톡이 설치되어 있는지 확인
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (error != null) {
                 Log.e("AuthViewModel", "카카오 로그인 실패", error)
                 _loginState.value = FirebaseLoginState.Error(error.message ?: "카카오 로그인 실패")
             } else if (token != null) {
                 Log.d("AuthViewModel", "카카오 로그인 성공: ${token.accessToken}")
-                // ★ 2. 받은 토큰으로 Cloud Function 호출
                 sendKakaoTokenToBackend(token.accessToken)
             }
         }
 
         if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-            // 카카오톡으로 로그인
             UserApiClient.instance.loginWithKakaoTalk(context, callback = callback)
         } else {
-            // 카카오계정(웹뷰)으로 로그인
             UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
         }
     }
 
     /**
-     * 2. [안드로이드] '카카오 토큰'을 Cloud Function으로 전송
+     * [안드로이드] '카카오 토큰'을 Cloud Function으로 전송
      */
     private fun sendKakaoTokenToBackend(kakaoAccessToken: String) {
         _loginState.value = FirebaseLoginState.Loading
@@ -122,7 +118,7 @@ class AuthViewModel : ViewModel() {
         val data = hashMapOf("token" to kakaoAccessToken)
 
         functions
-            .getHttpsCallable("kakaoLogin") // ★ 3. `index.ts`에 만든 함수 이름
+            .getHttpsCallable("kakaoLogin")
             .call(data)
             .continueWith { task ->
                 if (!task.isSuccessful) {
@@ -134,12 +130,10 @@ class AuthViewModel : ViewModel() {
                 viewModelScope.launch {
                     if (task.isSuccessful) {
                         try {
-                            // ★ 4. Cloud Function이 돌려준 '커스텀 토큰'
                             val firebaseCustomToken = task.result["firebaseToken"] as String
-
-                            // ★ 5. '커스텀 토큰'으로 Firebase에 최종 로그인
                             auth.signInWithCustomToken(firebaseCustomToken).await()
                             _loginState.value = FirebaseLoginState.Success
+                            _currentUserId.value = auth.currentUser?.uid // ID 업데이트
                         } catch (e: Exception) {
                             _loginState.value = FirebaseLoginState.Error(e.message ?: "커스텀 토큰 로그인 실패")
                         }
@@ -151,25 +145,19 @@ class AuthViewModel : ViewModel() {
     }
 
     fun loginWithNaverToken(naverAccessToken: String) {
-        // 1. UI 상태를 로딩 중으로 변경
         _loginState.value = FirebaseLoginState.Loading
 
         viewModelScope.launch {
             try {
-                // 2. Cloud Function에 전달할 데이터 맵 생성
-                //    (index.js에서 'naverAccessToken' 키로 받기로 약속했음)
                 val data = hashMapOf(
                     "naverAccessToken" to naverAccessToken
                 )
 
-                // 3. 배포된 "verifyNaverToken" Cloud Function 호출
                 val result = functions
                     .getHttpsCallable("verifyNaverToken")
                     .call(data)
                     .await()
 
-                // 4. 함수 실행 결과 (JSON) 파싱
-                //    (index.js에서 'firebaseCustomToken' 키로 반환하기로 약속했음)
                 @Suppress("UNCHECKED_CAST")
                 val resultMap = result.data as? Map<String, String>
                 val firebaseCustomToken = resultMap?.get("firebaseCustomToken")
@@ -180,12 +168,11 @@ class AuthViewModel : ViewModel() {
                     return@launch
                 }
 
-                // 5. Firebase 커스텀 토큰으로 Firebase에 최종 로그인
                 auth.signInWithCustomToken(firebaseCustomToken).await()
-                _loginState.value = FirebaseLoginState.Success // 성공!
+                _loginState.value = FirebaseLoginState.Success
+                _currentUserId.value = auth.currentUser?.uid // ID 업데이트
 
             } catch (e: Exception) {
-                // Cloud Function 호출 실패 또는 기타 에러
                 Log.e("AuthViewModel", "Cloud Function(verifyNaverToken) 호출 실패", e)
                 _loginState.value = FirebaseLoginState.Error(e.message ?: "네이버 로그인 실패")
             }
@@ -194,7 +181,37 @@ class AuthViewModel : ViewModel() {
 
     fun signOut() {
         auth.signOut()
-        // 로그아웃 시 UI가 로그인 화면으로 돌아가도록
-        _loginState.value = FirebaseLoginState.Idle // 상태 초기화
+        _loginState.value = FirebaseLoginState.Idle
+        _currentUserId.value = null // ID를 null로 설정
+        Log.d("AuthViewModel", "로그아웃 성공.")
+    }
+
+    /**
+     * [회원 탈퇴] 현재 로그인된 Firebase 계정을 삭제합니다.
+     */
+    fun deleteUserAndLogout() {
+        val user = auth.currentUser
+        if (user == null) {
+            _loginState.value = FirebaseLoginState.Error("로그인된 사용자가 없습니다.")
+            return
+        }
+
+        _loginState.value = FirebaseLoginState.Loading
+        viewModelScope.launch {
+            try {
+                user.delete().await()
+                _loginState.value = FirebaseLoginState.Idle
+                _currentUserId.value = null // ID를 null로 설정
+                Log.d("AuthViewModel", "회원 탈퇴 및 계정 삭제 성공.")
+
+            } catch (e: Exception) {
+                Log.e("AuthViewModel", "회원 탈퇴 실패", e)
+                if (e.message?.contains("REQUIRES_RECENT_LOGIN") == true) {
+                    _loginState.value = FirebaseLoginState.Error("보안을 위해 재로그인이 필요합니다.")
+                } else {
+                    _loginState.value = FirebaseLoginState.Error(e.message ?: "회원 탈퇴 실패")
+                }
+            }
+        }
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/login/JoinScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/login/JoinScreen.kt
@@ -100,7 +100,7 @@ fun JoinScreen(
             is FirebaseLoginState.Success -> {
                 Log.d("JoinScreen", "Firebase 회원가입 및 로그인 성공!")
                 // TODO: (중요) 회원가입 성공 시 홈 화면으로 이동
-                navController.navigate("todo") { popUpTo("auth_graph") { inclusive = true } }
+                navController.navigate("loading") { popUpTo("auth_graph") { inclusive = true } }
             }
 
             is FirebaseLoginState.Error -> {

--- a/Howsu/app/src/main/java/com/example/howsu/screen/login/LoadingScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/login/LoadingScreen.kt
@@ -1,5 +1,6 @@
 package com.example.howsu.screen.login
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -9,15 +10,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
-/**
- * 앱 시작 시 사용자의 로그인 상태를 확인하고 적절한 화면으로 분기하는 스크린
- */
 @Composable
 fun LoadingScreen(navController: NavController) {
 
-    // 화면 중앙에 로딩 스피너 표시
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
@@ -25,22 +23,44 @@ fun LoadingScreen(navController: NavController) {
         CircularProgressIndicator()
     }
 
-    // 이 Composable이 화면에 보일 때 '단 한 번' 실행
     LaunchedEffect(key1 = Unit) {
-        // Firebase.auth.currentUser는 현재 캐시된(로그인된) 사용자를 즉시 반환
         val currentUser = Firebase.auth.currentUser
+        val db = Firebase.firestore
 
         if (currentUser != null) {
-            // ★ 이미 로그인됨
-            // 메인 앱 화면 (원래라면 home으로)
-            navController.navigate("home") {   // home으로 변경
-                // LoadingScreen을 백스택에서 제거 (뒤로 가기 눌렀을 때 로딩 화면이 안 나오게)
-                // 0은 NavHost의 가장 루트를 의미
-                popUpTo(0) { inclusive = true }
-            }
+            // 로그인 되어 있음 -> DB에서 유저 정보 확인
+            val uid = currentUser.uid
+
+            // 'users' 컬렉션에서 현재 내 UID로 된 문서가 있는지, 닉네임이 있는지 확인
+            db.collection("users").document(uid).get()
+                .addOnSuccessListener { document ->
+                    // 문서가 존재하고, "nickname" 필드가 비어 있지 않다면 -> 가입 완료된 유저
+                    val nickname = document.getString("nickName") // DB 필드명 확인 필요 (nickName or nickname)
+
+                    if (document.exists() && !nickname.isNullOrBlank()) {
+                        // 1. 이미 정보 등록을 마친 유저 -> 홈으로
+                        Log.d("LoadingScreen", "기존 유저입니다. 홈으로 이동")
+                        navController.navigate("home") {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    } else {
+                        // 2. 로그인은 됐지만 닉네임이 없음 -> 닉네임 등록 화면으로
+                        Log.d("LoadingScreen", "신규 유저입니다. 등록 화면으로 이동")
+                        navController.navigate("register_nickname") {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
+                }
+                .addOnFailureListener { e ->
+                    // DB 조회 실패 (인터넷 문제 등) -> 안전하게 로그인 화면으로 보내거나 재시도 유도
+                    Log.e("LoadingScreen", "DB 조회 실패", e)
+                    navController.navigate("auth_graph") {
+                        popUpTo(0) { inclusive = true }
+                    }
+                }
+
         } else {
-            // ★ 로그인되지 않음
-            // 로그인/회원가입 그래프("auth_graph")로 이동
+            // ★ 로그인 안 되어 있음 -> 로그인 화면으로
             navController.navigate("auth_graph") {
                 popUpTo(0) { inclusive = true }
             }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/login/LoginScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/login/LoginScreen.kt
@@ -89,7 +89,7 @@ fun LoginScreen(
     LaunchedEffect(key1 = Unit) {
         if (Firebase.auth.currentUser != null) {
             Log.d("LoginScreen", "자동 로그인 확인.")
-            navController.navigate("todo") {
+            navController.navigate("loading") {
                 popUpTo("auth_graph") { inclusive = true }
             }
         }
@@ -100,7 +100,7 @@ fun LoginScreen(
         when (loginState) {
             is FirebaseLoginState.Success -> {
                 Log.d("LoginScreen", "Firebase 로그인 성공!")
-                navController.navigate("todo") { popUpTo("auth_graph") { inclusive = true } }
+                navController.navigate("loading") { popUpTo("auth_graph") { inclusive = true } }
             }
             is FirebaseLoginState.Error -> {
                 val message = (loginState as FirebaseLoginState.Error).message

--- a/Howsu/app/src/main/java/com/example/howsu/screen/pet/PetRegisterCompleteScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/pet/PetRegisterCompleteScreen.kt
@@ -1,0 +1,157 @@
+package com.example.howsu.screen.pet
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.howsu.data.model.BirthdayInputType
+import com.example.howsu.data.model.PetRegisterUiState
+
+
+@Composable
+fun PetRegisterCompleteScreen(
+    uiState: PetRegisterUiState,
+    onAddMore: () -> Unit,
+    onFinish: () -> Unit
+) {
+    Scaffold { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // 상단 완료 문구
+            Text(
+                text = "반려동물 등록이 완료되었어요!",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 프로필 + 이름
+            PetProfileCircle(
+                imageUrl = uiState.profilePetImageUrl,
+                size = 140.dp
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = uiState.petName.ifBlank { "우리 아이" },
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 상세 정보 박스
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(1.dp, Color(0xFFE0E0E0), RoundedCornerShape(16.dp))
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                InfoRow(label = "닉네임", value = uiState.nickName)
+                InfoRow(label = "성별", value = when (uiState.gender) {
+                    "MALE" -> "남아"
+                    "FEMALE" -> "여아"
+                    else -> "미입력"
+                })
+                InfoRow(
+                    label = "중성화",
+                    value = when (uiState.isNeutered) {
+                        true -> "했어요"
+                        false -> "안 했어요"
+                        null -> "미입력"
+                    }
+                )
+                InfoRow(
+                    label = "몸무게",
+                    value = if (uiState.weight.isNotBlank()) "${uiState.weight} kg" else "미입력"
+                )
+                InfoRow(
+                    label = "생년월일",
+                    value = when (uiState.birthdayInputType) {
+                        BirthdayInputType.EXACT ->
+                            if (uiState.birthdayExact.isNotBlank()) uiState.birthdayExact else "미입력"
+
+                        BirthdayInputType.APPROX -> {
+                            val y = uiState.birthdayYearApprox
+                            val m = uiState.birthdayMonthApprox
+                            if (y.isNotBlank() && m.isNotBlank()) "${y}년 ${m}월경"
+                            else "미입력"
+                        }
+                    }
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 버튼 2개
+            Button(
+                onClick = onAddMore,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Black,
+                    contentColor = Color.White
+                )
+            ) {
+                Text("반려동물 추가로 등록하기")
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                onClick = onFinish,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFFF5F5F5),
+                    contentColor = Color.Black
+                )
+            ) {
+                Text("그만하기")
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoRow(
+    label: String,
+    value: String
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label, color = Color.Gray, fontSize = 13.sp)
+        Text(text = value, fontSize = 13.sp)
+    }
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/pet/PetRegisterScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/pet/PetRegisterScreen.kt
@@ -1,0 +1,874 @@
+package com.example.howsu.screen.pet
+
+import android.annotation.SuppressLint
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+import com.example.howsu.Pet.PetRegisterViewModel
+import com.example.howsu.R
+import com.example.howsu.data.model.BirthdayInputType
+import com.example.howsu.data.model.PetRegisterStep
+import com.example.howsu.data.model.PetRegisterUiState
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+
+
+/* -----------------------------------------------------------------------
+   메인 화면
+   ----------------------------------------------------------------------- */
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PetRegisterScreen(
+    viewModel: PetRegisterViewModel,
+    navController: NavHostController
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showExitDialog by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+
+    // 이미지 선택 런처 (갤러리/드라이브 등)
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            val url = uri.toString()
+            when (uiState.step) {
+                PetRegisterStep.NICKNAME -> {
+                    viewModel.updateUserProfileImage(url)  // 닉네임 단계 → 유저 이미지
+                }
+                PetRegisterStep.PHOTO_NAME,
+                PetRegisterStep.GENDER_WEIGHT,
+                PetRegisterStep.BIRTHDAY -> {
+                    viewModel.updatePetProfileImage(url)   // 나머지 단계 → 펫 이미지
+                }
+            }
+        }
+    }
+
+    val (title, stepIndex) = when (uiState.step) {
+        PetRegisterStep.NICKNAME    -> "닉네임 등록하기" to 1
+        PetRegisterStep.PHOTO_NAME  -> "반려동물 등록하기" to 2
+        PetRegisterStep.GENDER_WEIGHT -> "반려동물 등록하기" to 3
+        PetRegisterStep.BIRTHDAY    -> "반려동물 등록하기" to 4
+    }
+
+    val isNicknameStep = uiState.step == PetRegisterStep.NICKNAME
+    val isLastStep = uiState.step == PetRegisterStep.BIRTHDAY
+
+    // 닉네임 단계에서는 닉네임 필수, 그 외 단계는 ViewModel 로직 사용
+    val nextButtonEnabled =
+        if (isNicknameStep) uiState.nickName.isNotBlank()
+        else viewModel.isNextEnabled()
+
+    Scaffold(
+        topBar = {
+            PetRegisterTopBar(
+                title = title,
+                step = stepIndex,
+                totalStep = 4,
+                onBack = {
+                    if (uiState.step == PetRegisterStep.NICKNAME) {
+                        navController.popBackStack()
+                    } else {
+                        viewModel.previousStep()
+                    }
+                },
+                showBack = uiState.step != PetRegisterStep.NICKNAME, // ← 닉네임 단계면 false
+                onCloseClick = { showExitDialog = true }
+            )
+        },
+        bottomBar = {
+            PetRegisterBottomBar(
+                enabled = nextButtonEnabled,                          // ← 여기만 수정
+                isLastStep = uiState.step == PetRegisterStep.BIRTHDAY,
+                showSkip = uiState.step != PetRegisterStep.NICKNAME,
+                onNext = {
+                    if (uiState.step == PetRegisterStep.BIRTHDAY) {
+                        viewModel.submit { _ ->
+                            navController.navigate("pet_register_complete")
+                        }
+                    } else {
+                        viewModel.nextStep()
+                    }
+                },
+                onSkip = { navController.navigate("home") }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when (uiState.step) {
+                PetRegisterStep.NICKNAME ->
+                    NicknameStep(
+                        state = uiState,
+                        onNickname = viewModel::updateNickName,
+                        onPickImage = {
+                            imagePickerLauncher.launch("image/*")
+                        }
+                    )
+
+                PetRegisterStep.PHOTO_NAME ->
+                    PhotoNameStep(
+                        state = uiState,
+                        onName = viewModel::updatePetName,
+                        onPickImage = {
+                            imagePickerLauncher.launch("image/*")
+                        }
+                    )
+
+                PetRegisterStep.GENDER_WEIGHT ->
+                    GenderWeightStep(
+                        state = uiState,
+                        onGender = viewModel::updateGender,
+                        onWeight = viewModel::updateWeight,
+                        onNeuteredChanged = viewModel::updateNeutered
+                    )
+
+                PetRegisterStep.BIRTHDAY ->
+                    BirthdayStep(
+                        state = uiState,
+                        onType = viewModel::updateBirthdayType,
+                        onExact = viewModel::updateBirthdayExact,
+                        onYear = viewModel::updateBirthdayYear,
+                        onMonth = viewModel::updateBirthdayMonth,
+                        onDatePickerClicked = { showDatePicker = true },
+                        selectedDate = datePickerState.selectedDateMillis
+                            ?: System.currentTimeMillis()
+                    )
+            }
+        }
+    }
+
+    // 달력 다이얼로그
+    if (showDatePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val millis = datePickerState.selectedDateMillis
+                        if (millis != null) {
+                            val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                            val formatted = formatter.format(Date(millis))
+                            viewModel.updateBirthdayExact(formatted)
+                        }
+                        showDatePicker = false
+                    }
+                ) { Text("확인") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text("취소")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    // X 눌렀을 때 나가기 경고
+    if (showExitDialog) {
+        AlertDialog(
+            onDismissRequest = { showExitDialog = false },
+            title = { Text("등록을 그만하시겠어요?") },
+            text = { Text("지금까지 입력한 내용은 저장되지 않고 삭제됩니다.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showExitDialog = false
+                        navController.popBackStack()
+                    }
+                ) {
+                    Text("나가기")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showExitDialog = false }) {
+                    Text("계속 작성할게요")
+                }
+            }
+        )
+    }
+}
+
+/* -----------------------------------------------------------------------
+   공통 TopBar / BottomBar
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun PetRegisterTopBar(
+    title: String,
+    step: Int,
+    totalStep: Int,
+    onBack: () -> Unit,
+    showBack: Boolean,              // ← 추가
+    onCloseClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .background(Color.White)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .height(48.dp)
+        ) {
+            // 왼쪽 뒤로가기 버튼
+            if (showBack) {          // ← 조건부로 표시
+                IconButton(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .size(39.dp)
+                        .align(Alignment.CenterStart)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "뒤로가기",
+                        modifier = Modifier.size(39.dp)
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.align(Alignment.Center),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = title,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Step $step/$totalStep",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                    fontSize = 13.sp
+                )
+            }
+
+            IconButton(
+                onClick = onCloseClick,
+                modifier = Modifier
+                    .size(39.dp)
+                    .align(Alignment.CenterEnd)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "닫기",
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(3.dp)
+                .background(Color(0xFFEDEDED))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(step.toFloat() / totalStep.toFloat())
+                    .background(Color.Black)
+            )
+        }
+    }
+}
+
+@Composable
+fun PetRegisterBottomBar(
+    enabled: Boolean,
+    isLastStep: Boolean,
+    showSkip: Boolean,          // ← 건너뛰기 보여줄지 여부 추가
+    onNext: () -> Unit,
+    onSkip: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 60.dp)
+    ) {
+        Button(
+            onClick = onNext,
+            enabled = enabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (enabled) Color.Black else Color(0xFFE0E0E0),
+                contentColor = if (enabled) Color.White else Color(0xFFBDBDBD)
+            )
+        ) {
+            Text(
+                text = if (isLastStep) "완료하기" else "계속하기",
+                fontWeight = FontWeight.Medium, fontSize = 14.sp
+            )
+        }
+
+        if (showSkip) {  // ← 여기서 조건부로 렌더링
+            Spacer(modifier = Modifier.height(13.dp))
+
+            Button(
+                onClick = onSkip,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(40.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Transparent,
+                    contentColor = Color.Gray
+                )
+            ) {
+                Text(
+                    text = "나중에 등록하고 싶어요! 건너뛰기",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+    }
+}
+
+
+/* -----------------------------------------------------------------------
+   공통 프로필 원
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun PetProfileCircle(
+    imageUrl: String?,
+    size: Dp = 180.dp,
+    onClick: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        // 프로필 원
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape) // 원 모양으로 잘라주기
+                .background(Color(0xFFF5F5F5)) // 배경색(없어도 됨)
+                .border(
+                    width = 2.dp,
+                    color = Color(0xFFEDEDED),
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            if (imageUrl.isNullOrBlank()) {
+                // 기본 상태일 때는 비워두거나 아이콘 넣기
+                // 예시: 가운데에 작은 아이콘
+                /* Icon(
+                    imageVector = Icons.Outlined.Pets,
+                    contentDescription = "기본 프로필",
+                    tint = Color.LightGray,
+                    modifier = Modifier.size(40.dp)
+                ) */
+            } else {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = "Pet Profile",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize() // 원 안을 꽉 채우기
+                )
+            }
+        }
+
+        // 카메라 아이콘 배지
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .offset(x = 2.dp, y = 2.dp)
+                .size(32.dp)
+                .background(Color.White, CircleShape)
+                .border(1.dp, Color(0xFFE0E0E0), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.PhotoCamera,
+                contentDescription = "사진 변경",
+                tint = Color.Gray,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+
+/* -----------------------------------------------------------------------
+   Step 0 : 닉네임 등록
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun NicknameStep(
+    state: PetRegisterUiState,
+    onNickname: (String) -> Unit,
+    onPickImage: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(28.dp))
+
+        PetProfileCircle(
+            imageUrl = state.profileUserImageUrl,
+            size = 200.dp,
+            onClick = onPickImage
+        )
+
+        Text(
+            text = "사용할 닉네임을 입력해 주세요.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.DarkGray
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = state.nickName,
+            onValueChange = onNickname,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("닉네임 입력하기") },
+            singleLine = true,
+            shape = RoundedCornerShape(16.dp)
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+/* -----------------------------------------------------------------------
+   Step 1 : 반려동물 이름 + 사진
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun PhotoNameStep(
+    state: PetRegisterUiState,
+    onName: (String) -> Unit,
+    onPickImage: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
+
+        PetProfileCircle(
+            imageUrl = state.profilePetImageUrl,
+            size = 200.dp,
+            onClick = onPickImage
+        )
+
+        Text(
+            text = "아이의 이름을 입력해 주세요.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.DarkGray
+        )
+
+        OutlinedTextField(
+            value = state.petName,
+            onValueChange = onName,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("이름 입력하기") },
+            singleLine = true,
+            shape = RoundedCornerShape(16.dp)
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+/* -----------------------------------------------------------------------
+   Step 2 : 성별 & 몸무게
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun GenderWeightStep(
+    state: PetRegisterUiState,
+    onGender: (String) -> Unit,
+    onWeight: (String) -> Unit,
+    onNeuteredChanged: (Boolean) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp)
+            .verticalScroll(rememberScrollState()),   // ← 스크롤 가능
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PetProfileCircle(
+            imageUrl = state.profilePetImageUrl,
+            size = 100.dp
+        )
+
+        Text(
+            text = state.petName.ifBlank { "우리 아이" },
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Text(
+            text = "성별은 무엇인가요?",
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            GenderChip(
+                text = "여아",
+                selected = state.gender == "FEMALE",
+                onClick = { onGender("FEMALE") },
+                modifier = Modifier.weight(1f)
+            )
+            GenderChip(
+                text = "남아",
+                selected = state.gender == "MALE",
+                onClick = { onGender("MALE") },
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        // 중성화 체크 한 줄
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    val current = state.isNeutered == true
+                    onNeuteredChanged(!current)
+                },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            RadioButton(
+                selected = state.isNeutered == true,
+                onClick = {
+                    val current = state.isNeutered == true
+                    onNeuteredChanged(!current)
+                }
+            )
+            Text(
+                text = "중성화했어요",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFF828282)
+            )
+        }
+
+        Text(
+            text = "몸무게는 몇 kg 인가요?",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.align(Alignment.Start),
+            fontSize = 16.sp
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedTextField(
+                value = state.weight,
+                onValueChange = onWeight,
+                modifier = Modifier.weight(1f),
+                placeholder = { Text("예) 2.3") },
+                singleLine = true,
+                shape = RoundedCornerShape(14.dp)
+            )
+
+            Text(
+                text = "kg",
+                style = MaterialTheme.typography.bodyMedium,
+                fontSize = 13.sp
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp)) // 여유만 조금 주기
+    }
+}
+
+@Composable
+fun GenderChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val bg = if (selected) Color.Black else Color.White
+    val border = if (selected) Color.Black else Color(0xFFE0E0E0)
+    val textColor = if (selected) Color.White else Color.Black
+
+    Box(
+        modifier = modifier
+            .height(44.dp)
+            .border(1.dp, border, RoundedCornerShape(24.dp))
+            .background(bg, RoundedCornerShape(24.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = text, color = textColor)
+    }
+}
+
+/* -----------------------------------------------------------------------
+   Step 3 : 생년월일 (정확 / 대략)
+   ----------------------------------------------------------------------- */
+
+@Composable
+fun BirthdayStep(
+    state: PetRegisterUiState,
+    onType: (BirthdayInputType) -> Unit,
+    onExact: (String) -> Unit,
+    onYear: (String) -> Unit,
+    onMonth: (String) -> Unit,
+    onDatePickerClicked: () -> Unit,
+    selectedDate: Long
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PetProfileCircle(
+            imageUrl = state.profilePetImageUrl,
+            size = 100.dp
+        )
+
+        Text(
+            text = state.petName.ifBlank { "우리 아이" },
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Text(
+            text = "생년월일을 알고 있나요?",
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RadioButton(
+                    selected = state.birthdayInputType == BirthdayInputType.EXACT,
+                    onClick = { onType(BirthdayInputType.EXACT) }
+                )
+                Text(text = "정확히 알고 있어요")
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RadioButton(
+                    selected = state.birthdayInputType == BirthdayInputType.APPROX,
+                    onClick = { onType(BirthdayInputType.APPROX) }
+                )
+                Text(text = "대략만 알고 있어요")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when (state.birthdayInputType) {
+            BirthdayInputType.EXACT -> {
+                DatePickerField(
+                    selectedDateMillis = selectedDate,
+                    onClick = onDatePickerClicked
+                )
+            }
+
+            BirthdayInputType.APPROX -> {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedTextField(
+                        value = state.birthdayYearApprox,
+                        onValueChange = onYear,
+                        modifier = Modifier.weight(1f),
+                        placeholder = { Text("년도 (예: 2021)") },
+                        singleLine = true,
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    OutlinedTextField(
+                        value = state.birthdayMonthApprox,
+                        onValueChange = onMonth,
+                        modifier = Modifier.weight(1f),
+                        placeholder = { Text("월 (1~12)") },
+                        singleLine = true,
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DatePickerField(
+    selectedDateMillis: Long,
+    onClick: () -> Unit
+) {
+    val formatter = SimpleDateFormat("yyyy년 MM월 dd일", Locale.getDefault())
+    val dateString = formatter.format(Date(selectedDateMillis))
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(17.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        onClick = onClick
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.calendar),
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Column {
+                Text("date", fontSize = 10.sp, color = Color.Gray)
+                Text(
+                    text = dateString,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 13.sp
+                )
+            }
+        }
+    }
+}
+
+/* -----------------------------------------------------------------------
+   프리뷰
+   ----------------------------------------------------------------------- */
+
+@SuppressLint("ViewModelConstructorInComposable")
+@Preview(showBackground = true)
+@Composable
+fun PetRegisterScreenPreview() {
+    val navController = rememberNavController()
+    val vm = PetRegisterViewModel()
+    PetRegisterScreen(viewModel = vm, navController = navController)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PhotoNameStepPreview() {
+    PhotoNameStep(
+        state = PetRegisterUiState(
+            step = PetRegisterStep.PHOTO_NAME
+        ),
+        onName = {},
+        onPickImage = {}
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GenderWeightStepPreview() {
+    GenderWeightStep(
+        state = PetRegisterUiState(
+            step = PetRegisterStep.GENDER_WEIGHT,
+            petName = "자몽"
+        ),
+        onGender = {},
+        onWeight = {},
+        onNeuteredChanged = {}
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BirthdayStepPreview() {
+    BirthdayStep(
+        state = PetRegisterUiState(
+            step = PetRegisterStep.BIRTHDAY,
+            petName = "자몽",
+            birthdayInputType = BirthdayInputType.EXACT
+        ),
+        onType = {},
+        onExact = {},
+        onYear = {},
+        onMonth = {},
+        onDatePickerClicked = {},
+        selectedDate = System.currentTimeMillis()
+    )
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/AlarmReceiver.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/AlarmReceiver.kt
@@ -5,12 +5,15 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import com.example.howsu.R // (R 임포트 경로 확인)
 
 class AlarmReceiver : BroadcastReceiver() {
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onReceive(context: Context, intent: Intent) {
         val scheduleId = intent.getStringExtra("SCHEDULE_ID") ?: return
         val title = intent.getStringExtra("SCHEDULE_TITLE") ?: "예약된 일정"
@@ -21,6 +24,7 @@ class AlarmReceiver : BroadcastReceiver() {
         sendNotification(context, scheduleId, title)
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun sendNotification(context: Context, scheduleId: String, title: String) {
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         val channelId = "SCHEDULE_NOTIFICATIONS"

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/AlarmReceiver.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/AlarmReceiver.kt
@@ -1,0 +1,50 @@
+package com.example.howsu.screen.schedule
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.example.howsu.R // (R 임포트 경로 확인)
+
+class AlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val scheduleId = intent.getStringExtra("SCHEDULE_ID") ?: return
+        val title = intent.getStringExtra("SCHEDULE_TITLE") ?: "예약된 일정"
+
+        Log.d("AlarmReceiver", "알림 수신: $scheduleId - $title")
+
+        // 알림을 표시
+        sendNotification(context, scheduleId, title)
+    }
+
+    private fun sendNotification(context: Context, scheduleId: String, title: String) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = "SCHEDULE_NOTIFICATIONS"
+
+        // (Android 8.0 이상) 알림 채널 생성
+        val channel = NotificationChannel(
+            channelId,
+            "일정 알림",
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = "등록된 일정에 대한 알림"
+        }
+        notificationManager.createNotificationChannel(channel)
+
+        // 알림 생성
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.ic_launcher_foreground) // ★ TODO: 알림 아이콘으로 변경
+            .setContentTitle("오늘의 일정 🐾")
+            .setContentText(title)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true) // 클릭 시 자동 삭제
+            .build()
+
+        // 알림 표시 (ID는 scheduleId의 해시코드)
+        notificationManager.notify(scheduleId.hashCode(), notification)
+    }
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleScreen.kt
@@ -1,5 +1,7 @@
 package com.example.howsu.screen.schedule
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -28,6 +30,7 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Comment
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Pets
@@ -61,14 +64,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -82,6 +89,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.howsu.R
 import com.example.howsu.data.model.Pet
 import com.example.howsu.ui.theme.HowsuTheme
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -93,7 +101,7 @@ fun CreateScheduleScreen(
     scheduleId: String? = null,
     viewModel: CreateScheduleViewModel = viewModel()
 ) {
-    // --- ViewModel 상태 구독 ---
+    // --- (기존 상태 구독 - 변경 없음) ---
     val allPets by viewModel.allPets.collectAsState()
     val selectedPets by viewModel.selectedPets.collectAsState()
     val isPetDropdownVisible by viewModel.isPetDropdownVisible.collectAsState()
@@ -103,28 +111,39 @@ fun CreateScheduleScreen(
     val selectedColor by viewModel.selectedColor.collectAsState()
     val predefinedColors = viewModel.predefinedColors
     val isColorPickerVisible by viewModel.isColorPickerVisible.collectAsState()
-
-    // ★ 날짜/시간 피커 상태
     val startDate by viewModel.startDate.collectAsState()
     val endDate by viewModel.endDate.collectAsState()
     val showDatePicker by viewModel.showDatePicker.collectAsState()
     val showTimePicker by viewModel.showTimePicker.collectAsState()
     val pickerTarget by viewModel.pickerTarget.collectAsState()
-
-    // ★ 반복/알림 상태
     val recurrenceRule by viewModel.recurrenceRule.collectAsState()
     val showRecurrencePicker by viewModel.showRecurrencePicker.collectAsState()
     val recurrenceOptions = viewModel.recurrenceOptions
     val alarmRule by viewModel.alarmRule.collectAsState()
     val showAlarmPicker by viewModel.showAlarmPicker.collectAsState()
     val alarmOptions = viewModel.alarmOptions
+    val recurrenceEndDate by viewModel.recurrenceEndDate.collectAsState()
+    val showRecurrenceEndDatePicker by viewModel.showRecurrenceEndDatePicker.collectAsState()
+
+    // --- (기존 쉐이크 애니메이션 - 변경 없음) ---
+    val scope = rememberCoroutineScope()
+    val shakeOffset = remember { Animatable(0f) }
+    fun triggerShake() {
+        scope.launch {
+            shakeOffset.animateTo(0f)
+            repeat(3) {
+                shakeOffset.animateTo(15f, tween(50))
+                shakeOffset.animateTo(-15f, tween(50))
+            }
+            shakeOffset.animateTo(0f, tween(50))
+        }
+    }
 
     LaunchedEffect(key1 = Unit) {
         viewModel.initialize(scheduleId)
     }
 
-    // --- ★ (신규) 날짜/시간 선택 다이얼로그 ---
-    // 날짜 선택기
+    // --- (기존 다이얼로그 - 변경 없음) ---
     if (showDatePicker) {
         val targetMillis = if (pickerTarget == DateTimePickerTarget.START) startDate else endDate
         val datePickerState = rememberDatePickerState(
@@ -145,7 +164,6 @@ fun CreateScheduleScreen(
         }
     }
 
-    // 시간 선택기
     if (showTimePicker) {
         val targetMillis = if (pickerTarget == DateTimePickerTarget.START) startDate else endDate
         val initialTime = Date(targetMillis)
@@ -153,7 +171,7 @@ fun CreateScheduleScreen(
             initialHour = initialTime.hours,
             initialMinute = initialTime.minutes
         )
-        TimePickerDialog( // (이 함수는 아래 13번에 새로 만듭니다)
+        TimePickerDialog(
             onDismissRequest = viewModel::onTimePickerDismissed,
             confirmButton = {
                 TextButton(onClick = {
@@ -168,6 +186,27 @@ fun CreateScheduleScreen(
         }
     }
 
+    if (showRecurrenceEndDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = recurrenceEndDate ?: System.currentTimeMillis()
+        )
+        DatePickerDialog(
+            onDismissRequest = { viewModel.onRecurrenceEndDateSelected(null) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.onRecurrenceEndDateSelected(datePickerState.selectedDateMillis)
+                }) { Text("확인") }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.onRecurrenceEndDateSelected(null) }) { Text("취소") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    val context = LocalContext.current
+
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
@@ -176,67 +215,80 @@ fun CreateScheduleScreen(
                 onCloseClick = { navController.popBackStack() }
             )
         },
-        bottomBar = {
-            CreateScheduleBottomButton(
-                onCreateClick = {
-                    viewModel.saveSchedule {
-                        // '자세히 보기' 화면에 "refresh" 신호 전달
-                        navController.previousBackStackEntry
-                            ?.savedStateHandle
-                            ?.set("refresh_needed", true) // "refresh_needed" 키에 true 저장
+        // ★★★ (수정) bottomBar 속성 제거
+        // bottomBar = { ... }
+    ) { innerPadding ->
 
-                        navController.popBackStack() // 2. 그 다음에 뒤로 감
+        // ★★★ (신규) Box로 래핑하여 버튼을 띄움
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding) // TopAppBar의 패딩은 여전히 적용
+        ) {
+            // (기존) 스크롤 가능한 본문
+            CreateScheduleContent (
+                modifier = Modifier.fillMaxSize(), // ★ Box를 꽉 채우도록
+                shakeOffset = shakeOffset.value,
+                title = title,
+                memo = memo,
+                isAllDay = isAllDay,
+                allPets = allPets,
+                selectedPets = selectedPets,
+                isPetDropdownVisible = isPetDropdownVisible,
+                selectedColor = selectedColor,
+                predefinedColors = predefinedColors,
+                isColorPickerVisible = isColorPickerVisible,
+                onColorSelected = viewModel::onColorSelected,
+                onColorPickerClicked = viewModel::onColorPickerClicked,
+                onColorPickerDismissed = viewModel::onColorPickerDismissed,
+                onTitleChanged = viewModel::onTitleChanged,
+                onMemoChanged = viewModel::onMemoChanged,
+                onAllDayToggled = viewModel::onAllDayToggled,
+                onPetDropdownClicked = viewModel::onPetDropdownClicked,
+                onPetDropdownDismissed = viewModel::onPetDropdownDismissed,
+                onPetSelected = viewModel::onPetSelected,
+                onPetTagRemoved = viewModel::onPetTagRemoved,
+                startDate = startDate,
+                endDate = endDate,
+                onDatePickerClicked = viewModel::onDatePickerClicked,
+                onTimePickerClicked = viewModel::onTimePickerClicked,
+                recurrenceRule = recurrenceRule,
+                showRecurrencePicker = showRecurrencePicker,
+                recurrenceOptions = recurrenceOptions,
+                onRecurrenceClicked = viewModel::onRecurrenceClicked,
+                onRecurrenceDismissed = viewModel::onRecurrenceDismissed,
+                onRecurrenceSelected = viewModel::onRecurrenceSelected,
+                alarmRule = alarmRule,
+                showAlarmPicker = showAlarmPicker,
+                alarmOptions = alarmOptions,
+                onAlarmClicked = viewModel::onAlarmClicked,
+                onAlarmDismissed = viewModel::onAlarmDismissed,
+                onAlarmSelected = viewModel::onAlarmSelected,
+                recurrenceEndDate = recurrenceEndDate,
+                onRecurrenceEndDateClicked = viewModel::onRecurrenceEndDateClicked
+            )
+
+            // ★★★ (신규) 하단 버튼을 Box의 바닥에 정렬
+            CreateScheduleBottomButton(
+                modifier = Modifier.align(Alignment.BottomCenter), // ★ 여기에 배치
+                onCreateClick = {
+                    if (title.isBlank()) {
+                        triggerShake()
+                    } else {
+                        viewModel.saveSchedule(context = context) {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set("refresh_needed", true)
+                            navController.popBackStack()
+                        }
                     }
                 }
             )
         }
-    ) { innerPadding ->
-        CreateScheduleContent (
-            modifier = Modifier.padding(innerPadding),
-            title = title,
-            memo = memo,
-            isAllDay = isAllDay,
-            allPets = allPets,
-            selectedPets = selectedPets,
-            isPetDropdownVisible = isPetDropdownVisible,
-            selectedColor = selectedColor,
-            predefinedColors = predefinedColors,
-            isColorPickerVisible = isColorPickerVisible,
-            onColorSelected = viewModel::onColorSelected,
-            onColorPickerClicked = viewModel::onColorPickerClicked,
-            onColorPickerDismissed = viewModel::onColorPickerDismissed,
-            onTitleChanged = viewModel::onTitleChanged,
-            onMemoChanged = viewModel::onMemoChanged,
-            onAllDayToggled = viewModel::onAllDayToggled,
-            onPetDropdownClicked = viewModel::onPetDropdownClicked,
-            onPetDropdownDismissed = viewModel::onPetDropdownDismissed,
-            onPetSelected = viewModel::onPetSelected,
-            onPetTagRemoved = viewModel::onPetTagRemoved,
-
-            // ★ 상태 및 핸들러 전달
-            startDate = startDate,
-            endDate = endDate,
-            onDatePickerClicked = viewModel::onDatePickerClicked,
-            onTimePickerClicked = viewModel::onTimePickerClicked,
-
-            recurrenceRule = recurrenceRule,
-            showRecurrencePicker = showRecurrencePicker,
-            recurrenceOptions = recurrenceOptions,
-            onRecurrenceClicked = viewModel::onRecurrenceClicked,
-            onRecurrenceDismissed = viewModel::onRecurrenceDismissed,
-            onRecurrenceSelected = viewModel::onRecurrenceSelected,
-
-            alarmRule = alarmRule,
-            showAlarmPicker = showAlarmPicker,
-            alarmOptions = alarmOptions,
-            onAlarmClicked = viewModel::onAlarmClicked,
-            onAlarmDismissed = viewModel::onAlarmDismissed,
-            onAlarmSelected = viewModel::onAlarmSelected
-        )
     }
 }
 
-// 상단 바 (★ 닫기 버튼 테두리 제거됨)
+// (기존) 상단 바 - 변경 없음
 @Composable
 private fun CreateScheduleTopBar(
     title: String,
@@ -260,7 +312,6 @@ private fun CreateScheduleTopBar(
             modifier = Modifier
                 .size(39.dp)
                 .align(Alignment.CenterEnd)
-            // .border(...) // ★ 테두리 삭제됨
         ) {
             Icon(
                 imageVector = Icons.Default.Close,
@@ -271,13 +322,24 @@ private fun CreateScheduleTopBar(
     }
 }
 
-// 하단 버튼
+// ★★★ (수정) 하단 버튼 - modifier 파라미터 추가, 패딩 수정
 @Composable
-private fun CreateScheduleBottomButton(onCreateClick: () -> Unit) {
+private fun CreateScheduleBottomButton(
+    modifier: Modifier = Modifier, // ★ 1. modifier 파라미터 추가
+    onCreateClick: () -> Unit
+) {
     Column(
-        modifier = Modifier
+        modifier = modifier // ★ 2. 전달받은 modifier 사용 (align(BottomCenter))
             .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = 60.dp)
+            // ★ 3. 배경을 투명하게 (Scaffold 배경이 보이도록)
+            .background(Color.Transparent)
+            // ★ 4. (수정) 패딩 변경 (상단 공백 16dp, 하단 공백 32dp)
+            .padding(
+                start = 24.dp,
+                end = 24.dp,
+                top = 16.dp,
+                bottom = 16.dp
+            )
     ) {
         Button(
             onClick = onCreateClick,
@@ -292,7 +354,7 @@ private fun CreateScheduleBottomButton(onCreateClick: () -> Unit) {
     }
 }
 
-// --- 섹션 래퍼 ---
+// (기존) 섹션 래퍼 - 변경 없음
 @Composable
 private fun CreateScheduleSection(
     icon: Painter,
@@ -320,10 +382,11 @@ private fun CreateScheduleSection(
 }
 
 
-// 본문 (스크롤 영역)
+// ★★★ (수정) 본문 (스크롤 영역) - 하단 패딩 추가
 @Composable
 private fun CreateScheduleContent(
     modifier: Modifier = Modifier,
+    shakeOffset: Float,
     title: String,
     memo: String,
     isAllDay: Boolean,
@@ -343,38 +406,46 @@ private fun CreateScheduleContent(
     onPetDropdownDismissed: () -> Unit,
     onPetSelected: (Pet) -> Unit,
     onPetTagRemoved: (Pet) -> Unit,
-
-    // ★ 날짜/시간/반복/알림 파라미터
     startDate: Long,
     endDate: Long,
     onDatePickerClicked: (DateTimePickerTarget) -> Unit,
     onTimePickerClicked: (DateTimePickerTarget) -> Unit,
-
     recurrenceRule: String,
     showRecurrencePicker: Boolean,
     recurrenceOptions: List<String>,
     onRecurrenceClicked: () -> Unit,
     onRecurrenceDismissed: () -> Unit,
     onRecurrenceSelected: (String) -> Unit,
-
     alarmRule: String,
     showAlarmPicker: Boolean,
     alarmOptions: List<String>,
     onAlarmClicked: () -> Unit,
     onAlarmDismissed: () -> Unit,
-    onAlarmSelected: (String) -> Unit
+    onAlarmSelected: (String) -> Unit,
+    recurrenceEndDate: Long?,
+    onRecurrenceEndDateClicked: () -> Unit
 ) {
+    val dateFormatter = SimpleDateFormat("yyyy.MM.dd 까지", Locale.KOREAN)
+    val recurrenceEndDateStr = recurrenceEndDate?.let { dateFormatter.format(Date(it)) } ?: "계속 반복"
+
     Column(
         modifier = modifier
-            .fillMaxSize()
+            // .fillMaxSize() // ★ Box에서 이미 적용됨
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 24.dp),
+            // ★ (수정) padding(horizontal = 24.dp) -> padding(...)
+            .padding(
+                start = 24.dp,
+                end = 24.dp,
+                // ★ (신규) 버튼 높이(56) + 상하패딩(16+32) = 104dp + 여유 16dp
+                bottom = 120.dp
+            ),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
         Spacer(modifier = Modifier.height(1.dp))
 
-        // --- 섹션 1: 제목 ---
+        // --- (기존) 섹션 1: 제목 ---
         ScheduleTitleField(
+            shakeOffset = shakeOffset,
             title = title,
             selectedColor = selectedColor,
             onTitleChanged = onTitleChanged,
@@ -385,12 +456,13 @@ private fun CreateScheduleContent(
             onColorSelected = onColorSelected
         )
 
-        // --- 섹션 2: 하루 종일 ---
+        // --- (기존) 섹션 2: 하루 종일 ---
         AllDaySwitch(
             isChecked = isAllDay,
             onCheckedChange = onAllDayToggled
         )
 
+        // --- (기존) 시간 선택 ---
         if (!isAllDay) {
             ScheduleTimePicker(
                 startDate = startDate,
@@ -402,23 +474,18 @@ private fun CreateScheduleContent(
             )
         }
 
-        Box(modifier = Modifier.fillMaxWidth()) { // 클릭 영역을 위한 Box
+        // --- (기존) 일정 반복 ---
+        Box(modifier = Modifier.fillMaxWidth()) {
             ScheduleSelectRow(
                 icon = Icons.Default.Refresh,
                 title = "일정 반복",
                 value = recurrenceRule,
-                onClick = onRecurrenceClicked // 이 클릭으로 메뉴를 토글
+                onClick = onRecurrenceClicked
             )
-
-            // ★ 1. 메뉴를 오른쪽 정렬하기 위한 추가 Box
-            Box(
-                modifier = Modifier.align(Alignment.TopEnd)
-            ) {
-                // ★ 2. DropdownMenu 자체의 modifier = Modifier.fillMaxWidth() 삭제
+            Box(modifier = Modifier.align(Alignment.TopEnd)) {
                 DropdownMenu(
                     expanded = showRecurrencePicker,
                     onDismissRequest = onRecurrenceDismissed
-                    // ★ modifier = Modifier.fillMaxWidth() 삭제!
                 ) {
                     recurrenceOptions.forEach { rule ->
                         DropdownMenuItem(
@@ -430,25 +497,30 @@ private fun CreateScheduleContent(
             }
         }
 
+        // --- (기존) '반복 종료 날짜' UI ---
+        if (recurrenceRule != "반복 안 함") {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                ScheduleSelectRow(
+                    icon = Icons.Default.Event,
+                    title = "반복 종료",
+                    value = recurrenceEndDateStr,
+                    onClick = onRecurrenceEndDateClicked
+                )
+            }
+        }
 
-        // --- ★ 섹션 5: 일정 미리 알림 (수정됨) ---
-        Box(modifier = Modifier.fillMaxWidth()) { // 클릭 영역을 위한 Box
+        // --- (기존) 일정 미리 알림 ---
+        Box(modifier = Modifier.fillMaxWidth()) {
             ScheduleSelectRow(
                 icon = Icons.Default.Notifications,
                 title = "일정 미리 알림",
                 value = alarmRule,
-                onClick = onAlarmClicked // 이 클릭으로 메뉴를 토글
+                onClick = onAlarmClicked
             )
-
-            // ★ 1. 메뉴를 오른쪽 정렬하기 위한 추가 Box
-            Box(
-                modifier = Modifier.align(Alignment.TopEnd)
-            ) {
-                // ★ 2. DropdownMenu 자체의 modifier = Modifier.fillMaxWidth() 삭제
+            Box(modifier = Modifier.align(Alignment.TopEnd)) {
                 DropdownMenu(
                     expanded = showAlarmPicker,
                     onDismissRequest = onAlarmDismissed
-                    // ★ modifier = Modifier.fillMaxWidth() 삭제!
                 ) {
                     alarmOptions.forEach { rule ->
                         DropdownMenuItem(
@@ -460,13 +532,13 @@ private fun CreateScheduleContent(
             }
         }
 
-        // --- 섹션 6: 한 줄 메모 ---
+        // --- (기존) 섹션 6: 한 줄 메모 ---
         CreateScheduleSection(
             icon = rememberVectorPainter(image = Icons.Default.Comment),
             title = "한 줄 메모"
         ) { ScheduleMemoField(memo = memo, onMemoChanged = onMemoChanged) }
 
-        // --- 섹션 7: 반려동물 선택 ---
+        // --- (기존) 섹션 7: 반려동물 선택 ---
         CreateScheduleSection(
             icon = rememberVectorPainter(image = Icons.Default.Pets),
             title = "반려동물 선택"
@@ -482,15 +554,16 @@ private fun CreateScheduleContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        // (삭제) Spacer(modifier = Modifier.height(32.dp)) -> 상단 Column의 padding(bottom=120.dp)로 대체
     }
 }
 
-// --- 본문 컴포넌트들 ---
+// --- (이하 나머지 Composable 함수들 - 변경 없음) ---
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ScheduleTitleField(
+    shakeOffset: Float,
     title: String,
     selectedColor: String,
     onTitleChanged: (String) -> Unit,
@@ -504,8 +577,12 @@ private fun ScheduleTitleField(
         value = title,
         onValueChange = onTitleChanged,
         placeholder = { Text("제목", fontSize = 20.sp, fontWeight = FontWeight.Bold, color = Color.Gray) },
-        modifier = Modifier.fillMaxWidth(),
-        textStyle = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold), // 폰트 통일
+        modifier = Modifier
+            .fillMaxWidth()
+            .graphicsLayer {
+                translationX = shakeOffset
+            },
+        textStyle = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold),
         trailingIcon = {
             Box {
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -521,7 +598,6 @@ private fun ScheduleTitleField(
                             .clip(CircleShape)
                             .background(Color(android.graphics.Color.parseColor(selectedColor)))
                             .clickable { onColorPickerClicked() }
-                            .border(BorderStroke(1.dp, Color.LightGray), CircleShape)
                     )
                     Spacer(modifier = Modifier.width(10.dp))
                 }
@@ -541,7 +617,6 @@ private fun ScheduleTitleField(
             focusedContainerColor = Color.Transparent,
             unfocusedContainerColor = Color.Transparent,
             disabledContainerColor = Color.Transparent,
-            // 밑줄 색상 통일
             focusedIndicatorColor = Color.LightGray.copy(alpha = 0.5f),
             unfocusedIndicatorColor = Color.LightGray.copy(alpha = 0.5f)
         ),
@@ -585,17 +660,12 @@ private fun ColorPickerRow(
 
 @Composable
 private fun AllDaySwitch(isChecked: Boolean, onCheckedChange: (Boolean) -> Unit) {
-    // 2. (신규) 스위치 색상 정의
     val customSwitchColors = SwitchDefaults.colors(
-        // "On" 상태 (선택됨)
         checkedTrackColor = Color.Black,
         checkedThumbColor = Color.White,
-        // "Off" 상태 (선택 안 됨)
         uncheckedTrackColor = Color.LightGray,
         uncheckedThumbColor = Color.White,
         uncheckedBorderColor = Color.LightGray,
-
-        // (비활성화 상태도 똑같이 보이도록 설정 - DetailScreen용)
         disabledCheckedTrackColor = Color.Black,
         disabledCheckedThumbColor = Color.White,
         disabledUncheckedTrackColor = Color.LightGray,
@@ -618,12 +688,11 @@ private fun AllDaySwitch(isChecked: Boolean, onCheckedChange: (Boolean) -> Unit)
             checked = isChecked,
             onCheckedChange = onCheckedChange,
             modifier = Modifier.scale(0.8f),
-            colors = customSwitchColors // 3. (신규) colors 속성 적용
+            colors = customSwitchColors
         )
     }
 }
 
-// --- ★ (수정됨) ScheduleTimePicker ---
 @Composable
 private fun ScheduleTimePicker(
     startDate: Long,
@@ -633,9 +702,7 @@ private fun ScheduleTimePicker(
     onEndDateClick: () -> Unit,
     onEndTimeClick: () -> Unit
 ) {
-    // Long(Millis) -> "M월 d일 (E)"
     val dateFormatter = SimpleDateFormat("M월 d일 (E)", Locale.KOREAN)
-    // Long(Millis) -> "오전/오후 hh:mm"
     val timeFormatter = SimpleDateFormat("a hh:mm", Locale.KOREAN)
 
     Row(
@@ -644,54 +711,47 @@ private fun ScheduleTimePicker(
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
     ) {
-        // --- 시작 시간 ---
         Column(
-            // modifier = Modifier.weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally // ★ 1. 시작 Column 중앙 정렬
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
                 text = dateFormatter.format(Date(startDate)),
                 fontSize = 14.sp,
                 color = Color.Gray,
-                modifier = Modifier.clickable(onClick = onStartDateClick) // 날짜 클릭
+                modifier = Modifier.clickable(onClick = onStartDateClick)
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = timeFormatter.format(Date(startDate)),
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
-                modifier = Modifier.clickable(onClick = onStartTimeClick) // 시간 클릭
+                modifier = Modifier.clickable(onClick = onStartTimeClick)
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f)) // ★ (신규) 왼쪽 스페이서
-
+        Spacer(modifier = Modifier.weight(1f))
         Icon(
             Icons.Default.ArrowForward,
             "에서",
-            modifier = Modifier
-                .size(20.dp)
+            modifier = Modifier.size(20.dp)
         )
+        Spacer(modifier = Modifier.weight(1f))
 
-        Spacer(modifier = Modifier.weight(1f)) // ★ (수정) 오른쪽 스페이서
-
-        // --- 종료 시간 ---
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally, // ★ 2. 종료 Column 중앙 정렬
-            // modifier = Modifier.weight(1f)
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = dateFormatter.format(Date(endDate)),
                 fontSize = 14.sp,
                 color = Color.Gray,
-                modifier = Modifier.clickable(onClick = onEndDateClick) // 날짜 클릭
+                modifier = Modifier.clickable(onClick = onEndDateClick)
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = timeFormatter.format(Date(endDate)),
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
-                modifier = Modifier.clickable(onClick = onEndTimeClick) // 시간 클릭
+                modifier = Modifier.clickable(onClick = onEndTimeClick)
             )
         }
     }
@@ -806,7 +866,6 @@ private fun PetTagChip(pet: Pet, onRemoveClick: () -> Unit) {
     }
 }
 
-// --- ★ (신규) TimePicker 다이얼로그 래퍼 ---
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TimePickerDialog(
@@ -820,15 +879,13 @@ fun TimePickerDialog(
         modifier = Modifier.fillMaxWidth()
     ) {
         Surface(
-            shape = RoundedCornerShape(28.dp) // 다이얼로그 모서리
+            shape = RoundedCornerShape(28.dp)
         ) {
             Column(
                 modifier = Modifier.padding(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                // TimePicker 본문 (시간 선택 휠)
                 content()
-                // 확인/취소 버튼
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleViewModel.kt
@@ -1,5 +1,9 @@
 package com.example.howsu.screen.schedule
 
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -20,6 +24,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
+import java.util.Calendar
 import java.util.Date
 
 enum class DateTimePickerTarget {
@@ -29,10 +34,9 @@ enum class DateTimePickerTarget {
 class CreateScheduleViewModel : ViewModel() {
 
     private val db = Firebase.firestore
-
     private var currentScheduleId: String? = null
 
-    // --- 상태(State) 정의 ---
+    // --- (기존 상태들) ---
     private val _allPets = MutableStateFlow<List<Pet>>(emptyList())
     val allPets: StateFlow<List<Pet>> = _allPets.asStateFlow()
     private val _selectedPets = MutableStateFlow<List<Pet>>(emptyList())
@@ -45,14 +49,10 @@ class CreateScheduleViewModel : ViewModel() {
     val memo: StateFlow<String> = _memo.asStateFlow()
     private val _isAllDay = MutableStateFlow(false)
     val isAllDay: StateFlow<Boolean> = _isAllDay.asStateFlow()
-
-    // 날짜/시간 상태
     private val _startDate = MutableStateFlow(System.currentTimeMillis())
     val startDate: StateFlow<Long> = _startDate.asStateFlow()
-    private val _endDate = MutableStateFlow(System.currentTimeMillis() + 3600000) // 1시간 뒤
+    private val _endDate = MutableStateFlow(System.currentTimeMillis() + 3600000)
     val endDate: StateFlow<Long> = _endDate.asStateFlow()
-
-    // 날짜/시간 피커 제어 상태
     private val _showDatePicker = MutableStateFlow(false)
     val showDatePicker: StateFlow<Boolean> = _showDatePicker.asStateFlow()
     private val _showTimePicker = MutableStateFlow(false)
@@ -60,20 +60,25 @@ class CreateScheduleViewModel : ViewModel() {
     private val _pickerTarget = MutableStateFlow(DateTimePickerTarget.START)
     val pickerTarget: StateFlow<DateTimePickerTarget> = _pickerTarget.asStateFlow()
 
+    // ★★★ (신규) 반복 종료 날짜 상태 ★★★
+    private val _recurrenceEndDate = MutableStateFlow<Long?>(null) // null이면 "계속 반복"
+    val recurrenceEndDate: StateFlow<Long?> = _recurrenceEndDate.asStateFlow()
+
+    private val _showRecurrenceEndDatePicker = MutableStateFlow(false)
+    val showRecurrenceEndDatePicker: StateFlow<Boolean> = _showRecurrenceEndDatePicker.asStateFlow()
+    // ★★★ (신규 끝) ★★★
+
     // 반복/알림 상태
     private val _recurrenceRule = MutableStateFlow("반복 안 함")
     val recurrenceRule: StateFlow<String> = _recurrenceRule.asStateFlow()
     private val _showRecurrencePicker = MutableStateFlow(false)
     val showRecurrencePicker: StateFlow<Boolean> = _showRecurrencePicker.asStateFlow()
     val recurrenceOptions = listOf("반복 안 함", "매일", "매주", "매월", "매년")
-
     private val _alarmRule = MutableStateFlow("설정 안 함")
     val alarmRule: StateFlow<String> = _alarmRule.asStateFlow()
     private val _showAlarmPicker = MutableStateFlow(false)
     val showAlarmPicker: StateFlow<Boolean> = _showAlarmPicker.asStateFlow()
     val alarmOptions = listOf("설정 안 함", "일정 시작 시간", "10분 전", "1시간 전", "1일 전")
-
-    // (색상 관련 상태 - 기존과 동일)
     private val _selectedColor = MutableStateFlow("#000000")
     val selectedColor: StateFlow<String> = _selectedColor.asStateFlow()
     private val _isColorPickerVisible = MutableStateFlow(false)
@@ -82,20 +87,17 @@ class CreateScheduleViewModel : ViewModel() {
         "#000000", "#4285F4", "#EA4335", "#34A853", "#FABC05", "#7986CB"
     )
 
+    // --- (기존 함수들 - 변경 없음) ---
     fun initialize(scheduleId: String?) {
         if (currentScheduleId == scheduleId && scheduleId != null) return
         currentScheduleId = scheduleId
-
         viewModelScope.launch {
             loadPetsData()
-            if (scheduleId != null) {
-                loadScheduleForEdit(scheduleId)
-            }
+            if (scheduleId != null) loadScheduleForEdit(scheduleId)
         }
     }
 
     private suspend fun loadPetsData() {
-        // (임시) 더미 데이터
         val dummyPets = listOf(
             Pet(petId = "pet_id_1", name = "자몽", profileImageUrl = null),
             Pet(petId = "pet_id_2", name = "레몬", profileImageUrl = null),
@@ -120,159 +122,124 @@ class CreateScheduleViewModel : ViewModel() {
                 _selectedPets.value = _allPets.value.filter { pet ->
                     schedule.petNames.contains(pet.name)
                 }
+                // (참고) 수정 시에는 반복 종료 날짜 로드 로직이 필요할 수 있으나,
+                // 현재는 '새로 생성' 시에만 반복을 지원하므로 생략합니다.
             }
         } catch (e: Exception) {
             Log.e("CreateScheduleVM", "수정할 일정($scheduleId) 로드 실패", e)
         }
     }
 
-    // --- 펫 관련 이벤트 핸들러 ---
-    fun onPetDropdownClicked() {
-        _isPetDropdownVisible.value = true
-    }
-
-    fun onPetDropdownDismissed() {
-        _isPetDropdownVisible.value = false
-    }
-
+    fun onPetDropdownClicked() { _isPetDropdownVisible.value = true }
+    fun onPetDropdownDismissed() { _isPetDropdownVisible.value = false }
     fun onPetSelected(pet: Pet) {
         if (!_selectedPets.value.any { it.petId == pet.petId }) {
             _selectedPets.update { it + pet }
         }
         _isPetDropdownVisible.value = false
     }
-
-    fun onPetTagRemoved(pet: Pet) {
-        _selectedPets.update { it.filterNot { p -> p.petId == pet.petId } }
-    }
-
-    // --- 일정 관련 이벤트 핸들러 ---
-    fun onTitleChanged(newTitle: String) {
-        _title.value = newTitle
-    }
-
-    fun onMemoChanged(newMemo: String) {
-        _memo.value = newMemo.take(20)
-    }
-
-    fun onAllDayToggled(isChecked: Boolean) {
-        _isAllDay.value = isChecked
-    }
-
+    fun onPetTagRemoved(pet: Pet) { _selectedPets.update { it.filterNot { p -> p.petId == pet.petId } } }
+    fun onTitleChanged(newTitle: String) { _title.value = newTitle }
+    fun onMemoChanged(newMemo: String) { _memo.value = newMemo.take(20) }
+    fun onAllDayToggled(isChecked: Boolean) { _isAllDay.value = isChecked }
     fun onColorSelected(hexColor: String) {
         _selectedColor.value = hexColor
-        _isColorPickerVisible.value = false // ★ 2. (수정) 색상 선택 시 팝업 닫기
-    }
-
-    // --- ★ 3. (신규) 색상 팝업 핸들러 ---
-    fun onColorPickerClicked() {
-        _isColorPickerVisible.value = true
-    }
-
-    fun onColorPickerDismissed() {
         _isColorPickerVisible.value = false
     }
-
-
+    fun onColorPickerClicked() { _isColorPickerVisible.value = true }
+    fun onColorPickerDismissed() { _isColorPickerVisible.value = false }
     fun onDatePickerClicked(target: DateTimePickerTarget) {
         _pickerTarget.value = target
         _showDatePicker.value = true
     }
-
-    fun onDatePickerDismissed() {
-        _showDatePicker.value = false
-    }
-
+    fun onDatePickerDismissed() { _showDatePicker.value = false }
     fun onDateSelected(selectedMillis: Long?) {
         _showDatePicker.value = false
         val selectedDate = Instant.ofEpochMilli(selectedMillis ?: System.currentTimeMillis())
             .atZone(ZoneId.systemDefault())
             .toLocalDate()
-
         updateDateTime(date = selectedDate)
     }
-
     fun onTimePickerClicked(target: DateTimePickerTarget) {
         _pickerTarget.value = target
         _showTimePicker.value = true
     }
-
-    fun onTimePickerDismissed() {
-        _showTimePicker.value = false
-    }
-
+    fun onTimePickerDismissed() { _showTimePicker.value = false }
     fun onTimeSelected(hour: Int, minute: Int) {
         _showTimePicker.value = false
         val selectedTime = LocalTime.of(hour, minute)
-
         updateDateTime(time = selectedTime)
     }
-
-    // 날짜 또는 시간이 선택됐을 때 _startDate, _endDate를 업데이트하는 헬퍼 함수
     private fun updateDateTime(date: LocalDate? = null, time: LocalTime? = null) {
         val targetState =
             if (_pickerTarget.value == DateTimePickerTarget.START) _startDate else _endDate
-
         val currentMillis = targetState.value
         val currentLocalDateTime = Instant.ofEpochMilli(currentMillis)
             .atZone(ZoneId.systemDefault())
             .toLocalDateTime()
-
-        // 새 날짜, 기존 시간 OR 기존 날짜, 새 시간
         val newDateTime = LocalDateTime.of(
             date ?: currentLocalDateTime.toLocalDate(),
             time ?: currentLocalDateTime.toLocalTime()
         )
-
-        // Long(Millis)로 변환하여 State 업데이트
         val newMillis = newDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
         targetState.value = newMillis
-
-        // (보너스) 시작 시간이 종료 시간보다 늦어지면, 종료 시간을 시작 시간 + 1시간으로 자동 설정
         if (_pickerTarget.value == DateTimePickerTarget.START && newMillis >= _endDate.value) {
             _endDate.value = newMillis + 3600000 // + 1 hour
         }
     }
-
-    // --- ★ 6. (신규) 반복/알림 이벤트 핸들러 ---
-    fun onRecurrenceClicked() {
-        _showRecurrencePicker.value = true
-    }
-
-    fun onRecurrenceDismissed() {
-        _showRecurrencePicker.value = false
-    }
-
+    fun onRecurrenceClicked() { _showRecurrencePicker.value = true }
+    fun onRecurrenceDismissed() { _showRecurrencePicker.value = false }
     fun onRecurrenceSelected(rule: String) {
         _recurrenceRule.value = rule
         _showRecurrencePicker.value = false
     }
-
-    fun onAlarmClicked() {
-        _showAlarmPicker.value = true
-    }
-
-    fun onAlarmDismissed() {
-        _showAlarmPicker.value = false
-    }
-
+    fun onAlarmClicked() { _showAlarmPicker.value = true }
+    fun onAlarmDismissed() { _showAlarmPicker.value = false }
     fun onAlarmSelected(rule: String) {
         _alarmRule.value = rule
         _showAlarmPicker.value = false
     }
 
-    fun saveSchedule(onComplete: () -> Unit) {
+    // ★★★ (신규) 반복 종료 날짜 핸들러 ★★★
+    fun onRecurrenceEndDateClicked() {
+        _showRecurrenceEndDatePicker.value = true
+    }
+
+    fun onRecurrenceEndDateSelected(selectedMillis: Long?) {
+        _showRecurrenceEndDatePicker.value = false
+        if (selectedMillis == null) {
+            // "취소" 누른 경우
+            return
+        }
+        // (선택된 날짜의 자정으로 설정)
+        val selectedDate = Instant.ofEpochMilli(selectedMillis)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate()
+            .atTime(23, 59, 59) // 그날 23:59:59 까지 포함
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+
+        _recurrenceEndDate.value = selectedDate
+    }
+
+    // (참고: '계속 반복'을 위한 초기화 기능, UI에 버튼 추가 시 사용)
+    // fun onRecurrenceEndDateClear() {
+    //     _recurrenceEndDate.value = null
+    // }
+    // ★★★ (신규 끝) ★★★
+
+    // --- ★ (수정) 저장 및 알림/반복 로직 ---
+    fun saveSchedule(context: Context, onComplete: () -> Unit) {
         val title = _title.value
         if (title.isBlank()) {
             return
         }
 
-        val scheduleMap = mapOf(
+        val baseScheduleMap = mapOf(
             "title" to title,
             "memo" to _memo.value,
             "isAllDay" to _isAllDay.value,
-            "startDate" to Timestamp(Date(_startDate.value)),
-            "endDate" to Timestamp(Date(_endDate.value)),
             "petNames" to _selectedPets.value.map { it.name },
             "color" to _selectedColor.value,
             "recurrenceRule" to _recurrenceRule.value,
@@ -281,19 +248,172 @@ class CreateScheduleViewModel : ViewModel() {
 
         viewModelScope.launch {
             try {
-                if (currentScheduleId == null) {
-                    // 새 일정 생성
-                    db.collection("schedules").add(scheduleMap).await()
-                    Log.d("CreateScheduleVM", "일정 생성 성공")
+                if (currentScheduleId == null && _recurrenceRule.value != "반복 안 함") {
+
+                    val batch = db.batch()
+                    val schedulesRef = db.collection("schedules")
+                    val duration = _endDate.value - _startDate.value
+
+                    // ★ (수정) 반복 날짜 계산
+                    val recurrenceDates = calculateNextRecurrenceDates(
+                        _startDate.value,
+                        _recurrenceRule.value,
+                        _recurrenceEndDate.value // ★ 종료 날짜 전달
+                    )
+
+                    recurrenceDates.forEach { startDateMillis ->
+                        val newDocRef = schedulesRef.document()
+                        val newEndDateMillis = startDateMillis + duration
+                        val newMap = baseScheduleMap.toMutableMap().apply {
+                            this["startDate"] = Timestamp(Date(startDateMillis))
+                            this["endDate"] = Timestamp(Date(newEndDateMillis))
+                        }
+                        batch.set(newDocRef, newMap)
+
+                        // ★ (수정) 모든 반복 일정에 알림 설정
+                        scheduleAlarm(
+                            context = context,
+                            scheduleId = newDocRef.id,
+                            title = title,
+                            startDateMillis = startDateMillis,
+                            alarmRule = _alarmRule.value
+                        )
+                    }
+
+                    batch.commit().await()
+                    Log.d("CreateScheduleVM", "${recurrenceDates.size}개 반복 일정 생성 성공")
+
                 } else {
-                    // 기존 일정 수정 (set으로 덮어쓰기)
-                    db.collection("schedules").document(currentScheduleId!!).set(scheduleMap)
-                        .await()
-                    Log.d("CreateScheduleVM", "일정 수정 성공")
+                    // --- 단일 일정 저장 또는 수정 ---
+                    val scheduleMap = baseScheduleMap.toMutableMap().apply {
+                        this["startDate"] = Timestamp(Date(_startDate.value))
+                        this["endDate"] = Timestamp(Date(_endDate.value))
+                    }
+
+                    val docId: String
+                    if (currentScheduleId == null) {
+                        val docRef = db.collection("schedules").add(scheduleMap).await()
+                        docId = docRef.id
+                        Log.d("CreateScheduleVM", "일정 생성 성공")
+                    } else {
+                        docId = currentScheduleId!!
+                        db.collection("schedules").document(docId).set(scheduleMap).await()
+                        Log.d("CreateScheduleVM", "일정 수정 성공")
+                    }
+
+                    // ★ 단일 일정 알림 설정
+                    scheduleAlarm(
+                        context = context,
+                        scheduleId = docId,
+                        title = title,
+                        startDateMillis = _startDate.value,
+                        alarmRule = _alarmRule.value
+                    )
                 }
+
                 onComplete() // 완료 후 화면 닫기
             } catch (e: Exception) {
                 Log.e("CreateScheduleVM", "저장 실패", e)
+            }
+        }
+    }
+
+    // --- ★ 10. (대폭 수정) 반복 날짜 계산 헬퍼 ---
+    private fun calculateNextRecurrenceDates(
+        startDateMillis: Long,
+        rule: String,
+        endDateMillis: Long? // ★ (신규) 반복 종료 날짜
+    ): List<Long> {
+        val dates = mutableListOf<Long>()
+        val calendar = Calendar.getInstance().apply { timeInMillis = startDateMillis }
+
+        // 1. 종료 날짜가 없으면, '계속 반복'으로 간주하고 임의로 1년치만 생성
+        // (365L * 24 * 60 * 60 * 1000) = 1년 뒤
+        val finalEndDateMillis = endDateMillis ?: (calendar.timeInMillis + 31536000000L)
+
+        // 2. 'while' 루프를 사용해 종료 날짜 전까지만 반복
+        while (calendar.timeInMillis <= finalEndDateMillis) {
+            dates.add(calendar.timeInMillis) // 현재 날짜 추가
+
+            // 다음 날짜로 이동
+            when (rule) {
+                "매일" -> calendar.add(Calendar.DAY_OF_YEAR, 1)
+                "매주" -> calendar.add(Calendar.WEEK_OF_YEAR, 1)
+                "매월" -> calendar.add(Calendar.MONTH, 1)
+                "매년" -> calendar.add(Calendar.YEAR, 1)
+                else -> break // "반복 안 함" 또는 예외
+            }
+        }
+
+        Log.d("CreateScheduleVM", "${dates.size}개의 반복 일정 날짜 생성됨 (종료: ${Date(finalEndDateMillis)})")
+        return dates
+    }
+
+
+    // --- ★ 11. (신규) 알림 시간 계산 헬퍼 ---
+    private fun calculateAlarmTime(startDateMillis: Long, alarmRule: String): Long? {
+        val tenMinutes = 10 * 60 * 1000
+        val oneHour = 60 * 60 * 1000
+        val oneDay = 24 * 60 * 60 * 1000
+
+        return when (alarmRule) {
+            "일정 시작 시간" -> startDateMillis
+            "10분 전" -> startDateMillis - tenMinutes
+            "1시간 전" -> startDateMillis - oneHour
+            "1일 전" -> startDateMillis - oneDay
+            else -> null // "설정 안 함"
+        }
+    }
+
+    // --- ★ 12. (신규) 알림 예약 헬퍼 ---
+    private fun scheduleAlarm(
+        context: Context,
+        scheduleId: String,
+        title: String,
+        startDateMillis: Long,
+        alarmRule: String
+    ) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        // 1. 알림 시간 계산
+        val triggerAtMillis = calculateAlarmTime(startDateMillis, alarmRule)
+
+        // 2. 알림 시간이 유효하고, 과거가 아닐 때만 예약
+        if (triggerAtMillis != null && triggerAtMillis > System.currentTimeMillis()) {
+
+            // 3. 알림을 수신할 Receiver 인텐트 생성
+            val intent = Intent(context, AlarmReceiver::class.java).apply {
+                putExtra("SCHEDULE_ID", scheduleId)
+                putExtra("SCHEDULE_TITLE", title)
+            }
+
+            // 4. PendingIntent 생성 (알림 ID로 scheduleId의 해시코드 사용)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                scheduleId.hashCode(), // 각 알림을 고유하게 식별할 ID
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            // 5. 알림 예약 (정시 알림)
+            try {
+                if (alarmManager.canScheduleExactAlarms()) {
+                    alarmManager.setExact(
+                        AlarmManager.RTC_WAKEUP,
+                        triggerAtMillis,
+                        pendingIntent
+                    )
+                    Log.d("CreateScheduleVM", "알림 예약 성공: $scheduleId at $triggerAtMillis")
+                } else {
+                    Log.w("CreateScheduleVM", "정시 알림 예약 권한이 없습니다.")
+                    alarmManager.set(
+                        AlarmManager.RTC_WAKEUP,
+                        triggerAtMillis,
+                        pendingIntent
+                    )
+                }
+            } catch (e: SecurityException) {
+                Log.e("CreateScheduleVM", "알림 예약 실패. 권한 필요 (SCHEDULE_EXACT_ALARM)", e)
             }
         }
     }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleViewModel.kt
@@ -4,9 +4,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.util.Log
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.howsu.data.model.Pet
@@ -133,29 +131,59 @@ class CreateScheduleViewModel : ViewModel() {
         }
     }
 
-    fun onPetDropdownClicked() { _isPetDropdownVisible.value = true }
-    fun onPetDropdownDismissed() { _isPetDropdownVisible.value = false }
+    fun onPetDropdownClicked() {
+        _isPetDropdownVisible.value = true
+    }
+
+    fun onPetDropdownDismissed() {
+        _isPetDropdownVisible.value = false
+    }
+
     fun onPetSelected(pet: Pet) {
         if (!_selectedPets.value.any { it.petId == pet.petId }) {
             _selectedPets.update { it + pet }
         }
         _isPetDropdownVisible.value = false
     }
-    fun onPetTagRemoved(pet: Pet) { _selectedPets.update { it.filterNot { p -> p.petId == pet.petId } } }
-    fun onTitleChanged(newTitle: String) { _title.value = newTitle }
-    fun onMemoChanged(newMemo: String) { _memo.value = newMemo.take(20) }
-    fun onAllDayToggled(isChecked: Boolean) { _isAllDay.value = isChecked }
+
+    fun onPetTagRemoved(pet: Pet) {
+        _selectedPets.update { it.filterNot { p -> p.petId == pet.petId } }
+    }
+
+    fun onTitleChanged(newTitle: String) {
+        _title.value = newTitle
+    }
+
+    fun onMemoChanged(newMemo: String) {
+        _memo.value = newMemo.take(20)
+    }
+
+    fun onAllDayToggled(isChecked: Boolean) {
+        _isAllDay.value = isChecked
+    }
+
     fun onColorSelected(hexColor: String) {
         _selectedColor.value = hexColor
         _isColorPickerVisible.value = false
     }
-    fun onColorPickerClicked() { _isColorPickerVisible.value = true }
-    fun onColorPickerDismissed() { _isColorPickerVisible.value = false }
+
+    fun onColorPickerClicked() {
+        _isColorPickerVisible.value = true
+    }
+
+    fun onColorPickerDismissed() {
+        _isColorPickerVisible.value = false
+    }
+
     fun onDatePickerClicked(target: DateTimePickerTarget) {
         _pickerTarget.value = target
         _showDatePicker.value = true
     }
-    fun onDatePickerDismissed() { _showDatePicker.value = false }
+
+    fun onDatePickerDismissed() {
+        _showDatePicker.value = false
+    }
+
     fun onDateSelected(selectedMillis: Long?) {
         _showDatePicker.value = false
         val selectedDate = Instant.ofEpochMilli(selectedMillis ?: System.currentTimeMillis())
@@ -163,16 +191,22 @@ class CreateScheduleViewModel : ViewModel() {
             .toLocalDate()
         updateDateTime(date = selectedDate)
     }
+
     fun onTimePickerClicked(target: DateTimePickerTarget) {
         _pickerTarget.value = target
         _showTimePicker.value = true
     }
-    fun onTimePickerDismissed() { _showTimePicker.value = false }
+
+    fun onTimePickerDismissed() {
+        _showTimePicker.value = false
+    }
+
     fun onTimeSelected(hour: Int, minute: Int) {
         _showTimePicker.value = false
         val selectedTime = LocalTime.of(hour, minute)
         updateDateTime(time = selectedTime)
     }
+
     private fun updateDateTime(date: LocalDate? = null, time: LocalTime? = null) {
         val targetState =
             if (_pickerTarget.value == DateTimePickerTarget.START) _startDate else _endDate
@@ -190,14 +224,28 @@ class CreateScheduleViewModel : ViewModel() {
             _endDate.value = newMillis + 3600000 // + 1 hour
         }
     }
-    fun onRecurrenceClicked() { _showRecurrencePicker.value = true }
-    fun onRecurrenceDismissed() { _showRecurrencePicker.value = false }
+
+    fun onRecurrenceClicked() {
+        _showRecurrencePicker.value = true
+    }
+
+    fun onRecurrenceDismissed() {
+        _showRecurrencePicker.value = false
+    }
+
     fun onRecurrenceSelected(rule: String) {
         _recurrenceRule.value = rule
         _showRecurrencePicker.value = false
     }
-    fun onAlarmClicked() { _showAlarmPicker.value = true }
-    fun onAlarmDismissed() { _showAlarmPicker.value = false }
+
+    fun onAlarmClicked() {
+        _showAlarmPicker.value = true
+    }
+
+    fun onAlarmDismissed() {
+        _showAlarmPicker.value = false
+    }
+
     fun onAlarmSelected(rule: String) {
         _alarmRule.value = rule
         _showAlarmPicker.value = false
@@ -226,14 +274,8 @@ class CreateScheduleViewModel : ViewModel() {
         _recurrenceEndDate.value = selectedDate
     }
 
-    // (참고: '계속 반복'을 위한 초기화 기능, UI에 버튼 추가 시 사용)
-    // fun onRecurrenceEndDateClear() {
-    //     _recurrenceEndDate.value = null
-    // }
-    // ★★★ (신규 끝) ★★★
 
     // --- ★ (수정) 저장 및 알림/반복 로직 ---
-    @RequiresApi(Build.VERSION_CODES.S)
     fun saveSchedule(context: Context, onComplete: () -> Unit) {
         val title = _title.value
 
@@ -376,7 +418,6 @@ class CreateScheduleViewModel : ViewModel() {
     }
 
     // --- ★ 12. (신규) 알림 예약 헬퍼 ---
-    @RequiresApi(Build.VERSION_CODES.S)
     private fun scheduleAlarm(
         context: Context,
         scheduleId: String,
@@ -385,46 +426,44 @@ class CreateScheduleViewModel : ViewModel() {
         alarmRule: String
     ) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-
-        // 1. 알림 시간 계산
         val triggerAtMillis = calculateAlarmTime(startDateMillis, alarmRule)
 
-        // 2. 알림 시간이 유효하고, 과거가 아닐 때만 예약
         if (triggerAtMillis != null && triggerAtMillis > System.currentTimeMillis()) {
-
-            // 3. 알림을 수신할 Receiver 인텐트 생성
             val intent = Intent(context, AlarmReceiver::class.java).apply {
                 putExtra("SCHEDULE_ID", scheduleId)
                 putExtra("SCHEDULE_TITLE", title)
             }
 
-            // 4. PendingIntent 생성 (알림 ID로 scheduleId의 해시코드 사용)
             val pendingIntent = PendingIntent.getBroadcast(
                 context,
-                scheduleId.hashCode(), // 각 알림을 고유하게 식별할 ID
+                scheduleId.hashCode(),
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 
-            // 5. 알림 예약 (정시 알림)
             try {
-                if (alarmManager.canScheduleExactAlarms()) {
-                    alarmManager.setExact(
-                        AlarmManager.RTC_WAKEUP,
-                        triggerAtMillis,
-                        pendingIntent
-                    )
-                    Log.d("CreateScheduleVM", "알림 예약 성공: $scheduleId at $triggerAtMillis")
+                // ★ 수정된 부분: 버전(SDK_INT)을 확인해서 분기 처리
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                    // 안드로이드 12(S) 이상: 권한 체크 필요
+                    if (alarmManager.canScheduleExactAlarms()) {
+                        alarmManager.setExact(
+                            AlarmManager.RTC_WAKEUP,
+                            triggerAtMillis,
+                            pendingIntent
+                        )
+                    } else {
+                        // 권한 없으면 일반 알림으로 (또는 로그 출력)
+                        alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+                    }
                 } else {
-                    Log.w("CreateScheduleVM", "정시 알림 예약 권한이 없습니다.")
-                    alarmManager.set(
-                        AlarmManager.RTC_WAKEUP,
-                        triggerAtMillis,
-                        pendingIntent
-                    )
+                    // 안드로이드 12 미만: 권한 체크 없이 바로 정확한 알림 사용 가능
+                    alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
                 }
+
+                Log.d("CreateScheduleVM", "알림 예약 성공")
+
             } catch (e: SecurityException) {
-                Log.e("CreateScheduleVM", "알림 예약 실패. 권한 필요 (SCHEDULE_EXACT_ALARM)", e)
+                Log.e("CreateScheduleVM", "알림 예약 실패", e)
             }
         }
     }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/CreateScheduleViewModel.kt
@@ -4,12 +4,15 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.howsu.data.model.Pet
 import com.example.howsu.data.model.Schedule
 import com.google.firebase.Timestamp
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.toObject
 import com.google.firebase.ktx.Firebase
@@ -230,13 +233,20 @@ class CreateScheduleViewModel : ViewModel() {
     // ★★★ (신규 끝) ★★★
 
     // --- ★ (수정) 저장 및 알림/반복 로직 ---
+    @RequiresApi(Build.VERSION_CODES.S)
     fun saveSchedule(context: Context, onComplete: () -> Unit) {
         val title = _title.value
+
+        // ★ 1. 유저 확인 및 familyId 확보 (투두와 동일한 패턴)
+        val currentUser = Firebase.auth.currentUser
+        val myFamilyId = currentUser?.uid ?: return
+
         if (title.isBlank()) {
             return
         }
 
         val baseScheduleMap = mapOf(
+            "familyId" to myFamilyId, // ★ 2. 맵에 familyId 추가
             "title" to title,
             "memo" to _memo.value,
             "isAllDay" to _isAllDay.value,
@@ -366,6 +376,7 @@ class CreateScheduleViewModel : ViewModel() {
     }
 
     // --- ★ 12. (신규) 알림 예약 헬퍼 ---
+    @RequiresApi(Build.VERSION_CODES.S)
     private fun scheduleAlarm(
         context: Context,
         scheduleId: String,

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleDetailScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding // ★ 1. (신규) 네비게이션 바 패딩
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -39,18 +40,25 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet // ★ 2. (신규) 바텀 시트
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberModalBottomSheetState // ★ 3. (신규) 바텀 시트 상태
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope // ★ 4. (신규) 코루틴 스코프
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,6 +67,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -67,6 +76,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.howsu.R
 import com.example.howsu.ui.theme.HowsuTheme
+import kotlinx.coroutines.launch // ★ 5. (신규) 코루틴 launch
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -84,15 +94,12 @@ fun ScheduleDetailScreen(
 
     val refreshTrigger = navController.currentBackStackEntry
         ?.savedStateHandle
-        ?.getStateFlow("refresh_needed", false) // 1. "refresh_needed" 키를 관찰
+        ?.getStateFlow("refresh_needed", false)
         ?.collectAsState()
 
     LaunchedEffect(key1 = refreshTrigger?.value) {
         if (refreshTrigger?.value == true) {
-            // 2. 신호가 true이면, 데이터를 강제로 새로고침
             viewModel.loadScheduleDetails(scheduleId)
-
-            // 3. (중요) 신호를 받았으니 다시 false로 리셋
             navController.currentBackStackEntry
                 ?.savedStateHandle
                 ?.set("refresh_needed", false)
@@ -100,6 +107,11 @@ fun ScheduleDetailScreen(
     }
 
     val schedule by viewModel.selectedSchedule.collectAsState()
+
+    // ★★★ 6. (수정) 바텀 시트 상태 관리
+    var showDeleteSheet by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -119,13 +131,9 @@ fun ScheduleDetailScreen(
         bottomBar = {
             DeleteScheduleBottomButton(
                 onDeleteClick = {
+                    // ★★★ 7. (수정) 삭제 버튼 클릭 시 시트 표시
                     if (scheduleId != null) {
-                        viewModel.deleteSchedule(scheduleId) {
-                            navController.previousBackStackEntry
-                                ?.savedStateHandle
-                                ?.set("refresh_needed", true)
-                            navController.popBackStack()
-                        }
+                        showDeleteSheet = true
                     } else {
                         Log.e("ScheduleDetailScreen", "scheduleId가 null이라 삭제할 수 없습니다.")
                     }
@@ -133,6 +141,42 @@ fun ScheduleDetailScreen(
             )
         }
     ) { innerPadding ->
+
+        // ★★★ 8. (수정) 바텀 시트 로직
+        if (showDeleteSheet) {
+            ModalBottomSheet(
+                onDismissRequest = { showDeleteSheet = false },
+                sheetState = sheetState
+            ) {
+                // 바텀 시트의 내용물 (새로 만든 Composable)
+                DeleteOptionsBottomSheet(
+                    onConfirm = { deletionType ->
+                        // 1. 시트를 닫음
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            if (!sheetState.isVisible) {
+                                showDeleteSheet = false
+                            }
+                        }
+                        // 2. 뷰모델 호출
+                        viewModel.deleteSchedule(deletionType) {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set("refresh_needed", true)
+                            navController.popBackStack()
+                        }
+                    },
+                    onDismiss = {
+                        // '취소' 버튼 클릭 시
+                        scope.launch { sheetState.hide() }.invokeOnCompletion {
+                            if (!sheetState.isVisible) {
+                                showDeleteSheet = false
+                            }
+                        }
+                    }
+                )
+            }
+        }
+
 
         if (schedule == null) {
             Box(
@@ -146,28 +190,18 @@ fun ScheduleDetailScreen(
             return@Scaffold
         }
 
+        // --- (이하 기존 UI 코드는 변경 없음) ---
         val scheduleData = schedule!!
-
-        // 시간 포맷팅
         val dateFormatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
         val timeFormatter = DateTimeFormatter.ofPattern("a hh:mm", Locale.KOREAN)
         val zoneId = ZoneId.systemDefault()
-
-        val startDateStr = scheduleData.startDate.toDate().toInstant().atZone(zoneId)
-            .format(dateFormatter)
-        val startTimeStr = scheduleData.startDate.toDate().toInstant().atZone(zoneId)
-            .format(timeFormatter)
-        val endDateStr = scheduleData.endDate.toDate().toInstant().atZone(zoneId)
-            .format(dateFormatter)
-        val endTimeStr = scheduleData.endDate.toDate().toInstant().atZone(zoneId)
-            .format(timeFormatter)
-
-        // 색상 파싱
+        val startDateStr = scheduleData.startDate.toDate().toInstant().atZone(zoneId).format(dateFormatter)
+        val startTimeStr = scheduleData.startDate.toDate().toInstant().atZone(zoneId).format(timeFormatter)
+        val endDateStr = scheduleData.endDate.toDate().toInstant().atZone(zoneId).format(dateFormatter)
+        val endTimeStr = scheduleData.endDate.toDate().toInstant().atZone(zoneId).format(timeFormatter)
         val scheduleColor = try {
             Color(android.graphics.Color.parseColor(scheduleData.color))
-        } catch (e: Exception) {
-            Color(0xFF4285F4) // 파싱 실패 시 파란색
-        }
+        } catch (e: Exception) { Color(0xFF4285F4) }
 
         Column(
             modifier = Modifier
@@ -175,13 +209,10 @@ fun ScheduleDetailScreen(
                 .padding(innerPadding)
                 .padding(horizontal = 24.dp)
                 .verticalScroll(rememberScrollState()),
-            // ★ (수정) '수정하기' 화면과 동일하게 20.dp
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            // ★ (수정) '수정하기' 화면과 동일하게 1.dp
             Spacer(modifier = Modifier.height(1.dp))
 
-            // --- 제목 --- (CreateScheduleScreen과 스타일 동일하게 맞춤)
             TextField(
                 value = scheduleData.title,
                 onValueChange = {},
@@ -225,30 +256,24 @@ fun ScheduleDetailScreen(
                 maxLines = 1
             )
 
-            // --- "하루 종일" (★ 수정됨) ---
             DetailAllDaySwitchRow(
                 icon = Icons.Default.Schedule,
                 title = "하루 종일",
                 isChecked = scheduleData.isAllDay
             )
 
-            // --- "날짜" (★ '하루 종일'이 아닐 때만 표시) ---
             if (!scheduleData.isAllDay) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp) // '수정하기'와 동일한 16dp
+                        .padding(horizontal = 16.dp)
                 ) {
-                    // --- 1. 시작 날짜/시간 ---
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(startDateStr, fontSize = 14.sp, color = Color.Gray)
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(startTimeStr, fontSize = 14.sp, fontWeight = FontWeight.Medium)
                     }
-
                     Spacer(modifier = Modifier.weight(1f))
                     Icon(
                         imageVector = Icons.Default.ArrowForward,
@@ -256,11 +281,7 @@ fun ScheduleDetailScreen(
                         modifier = Modifier.size(20.dp)
                     )
                     Spacer(modifier = Modifier.weight(1f))
-
-                    // --- 3. 종료 날짜/시간 ---
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(endDateStr, fontSize = 14.sp, color = Color.Gray)
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(endTimeStr, fontSize = 14.sp, fontWeight = FontWeight.Medium)
@@ -268,21 +289,16 @@ fun ScheduleDetailScreen(
                 }
             }
 
-            // --- "반복" (★ 수정됨) ---
             DetailSelectRow(
                 icon = Icons.Default.Refresh,
                 title = "일정 반복",
-                value = "매일" // (TODO: scheduleData.repeatRule)
+                value = scheduleData.recurrenceRule
             )
-
-            // --- "알림" (★ 수정됨) ---
             DetailSelectRow(
                 icon = Icons.Default.Notifications,
                 title = "일정 미리 알림",
-                value = "1일 전 오후 5:00" // (TODO: scheduleData.alarmRule)
+                value = scheduleData.alarmRule
             )
-
-            // --- "한 줄 메모" (★ 수정됨) ---
             DetailInfoColumn(
                 icon = Icons.Default.Comment,
                 title = "한 줄 메모"
@@ -291,38 +307,83 @@ fun ScheduleDetailScreen(
                     value = scheduleData.memo,
                     onValueChange = {},
                     readOnly = true,
-                    enabled = false, // 비활성화 상태로 readOnly 스타일 적용
+                    enabled = false,
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(17.dp), // '수정하기'와 동일
+                    shape = RoundedCornerShape(17.dp),
                     placeholder = { Text(
                         "메모가 없습니다.",
-                        fontWeight = FontWeight.Medium, // '수정하기'와 동일
-                        fontSize = 13.sp // '수정하기'와 동일
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 13.sp
                     ) },
                     maxLines = 3
                 )
             }
-
-            // --- "반료동물" (★ 수정됨) ---
             DetailInfoColumn(
                 icon = Icons.Default.Pets,
-                title = "반려동물" // '수정하기'에서는 "반려동물 선택"
+                title = "반려동물"
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    // '수정하기'의 PetTagChip 대신 PetChip 사용 (스타일 다름)
                     scheduleData.petNames.forEach { petName ->
                         PetChip(name = petName)
                     }
                 }
             }
-
-            // ★ (수정) '수정하기' 화면과 동일하게 32.dp
             Spacer(modifier = Modifier.height(32.dp))
         }
     }
 }
 
-// --- TopBar (수정 없음) ---
+// ★★★ 바텀 시트 전용 Content Composable ★★★
+@Composable
+fun DeleteOptionsBottomSheet(
+    onConfirm: (DeletionType) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding() // 하단 네비게이션 바 겹침 방지
+            .padding(top = 8.dp)
+    ) {
+
+        // (옵션 1: 단일 삭제)
+        TextButton(
+            onClick = { onConfirm(DeletionType.SINGLE) },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(0.dp)
+        ) {
+            Text(
+                "이 일정만 바로 삭제하기",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                textAlign = TextAlign.Start,
+                color = MaterialTheme.colorScheme.onSurface, // ★ 기본 색상
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+
+        // (옵션 2: 이후 삭제 - 빨간색)
+        TextButton(
+            onClick = { onConfirm(DeletionType.FUTURE) },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(0.dp)
+        ) {
+            Text(
+                "이 일정과 이후 반복 일정 모두 삭제하기",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+                textAlign = TextAlign.Start,
+                color = Color.Red,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp)) // 하단 여백
+    }
+}
+
 @Composable
 private fun DetailTopBar(onBackClick: () -> Unit, onEditClick: () -> Unit) {
     Box(
@@ -363,15 +424,12 @@ private fun DetailAllDaySwitchRow(
     title: String,
     isChecked: Boolean
 ) {
-    // 2. (신규) '수정' 화면과 동일한 색상 정의
     val customSwitchColors = SwitchDefaults.colors(
         checkedTrackColor = Color.Black,
         checkedThumbColor = Color.White,
         uncheckedTrackColor = Color.LightGray,
         uncheckedThumbColor = Color.White,
         uncheckedBorderColor = Color.LightGray,
-
-        // ★ '자세히 보기'는 disabled 상태이므로 이 색상이 적용됨
         disabledCheckedTrackColor = Color.Black,
         disabledCheckedThumbColor = Color.White,
         disabledUncheckedTrackColor = Color.LightGray,
@@ -383,31 +441,22 @@ private fun DetailAllDaySwitchRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp) // '수정'과 동일한 8dp
+            .padding(vertical = 8.dp)
     ) {
-        Icon(
-            icon,
-            title,
-            modifier = Modifier.size(22.dp) // '수정'과 동일한 22dp
-        )
-        Spacer(modifier = Modifier.width(12.dp)) // '수정'과 동일한 12dp
-        Text(
-            title,
-            fontSize = 14.sp, // '수정'과 동일한 14sp
-            fontWeight = FontWeight.Bold // '수정'과 동일한 Bold
-        )
+        Icon(icon, title, modifier = Modifier.size(22.dp))
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold)
         Spacer(modifier = Modifier.weight(1f))
         Switch(
             checked = isChecked,
             onCheckedChange = null,
-            enabled = false, // 자세히 보기이므로 비활성화
-            modifier = Modifier.scale(0.8f), // '수정'과 동일한 스케일
-            colors = customSwitchColors // 3. (신규) colors 속성 적용
+            enabled = false,
+            modifier = Modifier.scale(0.8f),
+            colors = customSwitchColors
         )
     }
 }
 
-// --- ★ (신규) "반복", "알림" Row ---
 @Composable
 private fun DetailSelectRow(
     icon: ImageVector,
@@ -415,57 +464,33 @@ private fun DetailSelectRow(
     value: String
 ) {
     Column {
-        Divider(color = Color.LightGray.copy(alpha = 0.5f)) // '수정'과 동일한 Divider
+        Divider(color = Color.LightGray.copy(alpha = 0.5f))
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 16.dp) // '수정'과 동일한 16dp
+                .padding(vertical = 16.dp)
         ) {
-            Icon(
-                icon,
-                title,
-                modifier = Modifier.size(22.dp) // '수정'과 동일한 22dp
-            )
-            Spacer(modifier = Modifier.width(12.dp)) // '수정'과 동일한 12dp
-            Text(
-                title,
-                fontSize = 14.sp, // '수정'과 동일한 14sp
-                fontWeight = FontWeight.Bold // '수정'과 동일한 Bold
-            )
+            Icon(icon, title, modifier = Modifier.size(22.dp))
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold)
             Spacer(modifier = Modifier.weight(1f))
-            Text(
-                value,
-                fontSize = 14.sp, // '수정'과 동일한 14sp
-                fontWeight = FontWeight.Bold, // '수정'과 동일한 Bold
-                color = Color.Gray
-            )
-            // '자세히 보기'에는 'v' 아이콘이 없으므로 생략
+            Text(value, fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color.Gray)
         }
     }
 }
 
-// --- ★ (신규) "메모", "반려동물" Column ---
 @Composable
 private fun DetailInfoColumn(icon: ImageVector, title: String, content: @Composable () -> Unit) {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp) // '수정'과 동일
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                icon,
-                title,
-                modifier = Modifier.size(22.dp) // '수정'과 동일
-            )
-            Spacer(modifier = Modifier.width(8.dp)) // '수정'과 동일
-            Text(
-                title,
-                fontSize = 14.sp, // '수정'과 동일
-                fontWeight = FontWeight.Bold // '수정'과 동일
-            )
+            Icon(icon, title, modifier = Modifier.size(22.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold)
         }
-        // '수정' (22dp + 8dp = 30dp)와 동일한 패딩
         Box(modifier = Modifier.padding(start = 30.dp)) {
             content()
         }
@@ -473,7 +498,6 @@ private fun DetailInfoColumn(icon: ImageVector, title: String, content: @Composa
 }
 
 
-// --- PetChip (수정 없음) ---
 @Composable
 private fun PetChip(name: String) {
     Surface(
@@ -498,7 +522,6 @@ private fun PetChip(name: String) {
     }
 }
 
-// --- BottomBar (수정 없음) ---
 @Composable
 private fun DeleteScheduleBottomButton(onDeleteClick: () -> Unit) {
     Column(
@@ -522,7 +545,6 @@ private fun DeleteScheduleBottomButton(onDeleteClick: () -> Unit) {
     }
 }
 
-// --- Preview (수정 없음) ---
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
 fun ScheduleDetailScreenPreview() {

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleScreeen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleScreeen.kt
@@ -172,7 +172,8 @@ fun ScheduleScreen(
         floatingActionButton = {
             MyFloatingActionButton(
                 onTodoClick = { navController.navigate("create_todo") },
-                onScheduleClick = { navController.navigate("create_schedule") }
+                onScheduleClick = { navController.navigate("create_schedule") },
+                onFeedCreateClick = { navController.navigate("create_feed") }
             )
         },
     ) { innerPadding ->

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleScreeen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleScreeen.kt
@@ -25,12 +25,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.icons.filled.ArrowForwardIos
-import androidx.compose.material.icons.filled.Event // ★ (신규) '하루 종일' 아이콘
-import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Pets
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar // ★★★ 1. (수정) Import 변경
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -39,8 +39,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarDefaults // ★★★ 2. (수정) Import 추가 (필요)
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -84,17 +83,13 @@ fun ScheduleScreen(
     navController: NavHostController,
     viewModel: ScheduleViewModel = viewModel()
 ) {
-    // --- ViewModel 상태 ---
+    // --- (기존 상태들 - 변경 없음) ---
     val schedules by viewModel.schedules.collectAsState()
     val selectedDate by viewModel.selectedDate.collectAsState()
     val currentMonth by viewModel.currentMonth.collectAsState()
     val monthSchedules by viewModel.monthSchedules.collectAsState()
     var showMonthPicker by remember { mutableStateOf(false) }
-
-    // --- 캘린더 확장/축소 상태 ---
     var isCalendarExpanded by remember { mutableStateOf(false) }
-
-    // --- 새로고침 로직 ---
     val refreshTrigger = navController.currentBackStackEntry
         ?.savedStateHandle
         ?.getStateFlow("refresh_needed", false)
@@ -109,7 +104,6 @@ fun ScheduleScreen(
         }
     }
 
-    // --- NestedScrollConnection 로직 ---
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
@@ -156,16 +150,38 @@ fun ScheduleScreen(
     Scaffold(
         containerColor = Color.White,
         topBar = {
-            TopAppBar(
+            // ★★★ 3. (수정) CenterAlignedTopAppBar로 교체
+            CenterAlignedTopAppBar(
                 title = {
+                    // ★★★ 4. (수정) 텍스트와 클릭 영역만 남김
                     CalendarHeader(
                         yearMonth = "${currentMonth.year}년 ${currentMonth.monthValue}월",
-                        onPrevClick = { viewModel.onMonthChange(false) },
-                        onNextClick = { viewModel.onMonthChange(true) },
                         onMonthArrowClick = { showMonthPicker = true }
                     )
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
+
+                // ★★★ 5. (신규) 이전 버튼을 navigationIcon으로 이동
+                navigationIcon = {
+                    IconButton(onClick = { viewModel.onMonthChange(false) }) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBackIosNew,
+                            contentDescription = "이전 달",
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                },
+
+                // ★★★ 6. (신규) 다음 버튼을 actions로 이동
+                actions = {
+                    IconButton(onClick = { viewModel.onMonthChange(true) }) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowForwardIos,
+                            contentDescription = "다음 달",
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
             )
         },
         bottomBar = { MyBottomNavigationBar(navController = navController) },
@@ -173,7 +189,7 @@ fun ScheduleScreen(
             MyFloatingActionButton(
                 onTodoClick = { navController.navigate("create_todo") },
                 onScheduleClick = { navController.navigate("create_schedule") },
-                onFeedCreateClick = { navController.navigate("feed_create") }
+                onFeedCreateClick = { navController.navigate("create_feed") }
             )
         },
     ) { innerPadding ->
@@ -189,14 +205,13 @@ fun ScheduleScreen(
             )
         }
 
+        // --- (이하 모든 코드 변경 없음) ---
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
                 .nestedScroll(nestedScrollConnection)
         ) {
-
-            // --- 1. 캘린더 영역 ---
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -205,7 +220,7 @@ fun ScheduleScreen(
                     .pointerInput(Unit) {
                         detectVerticalDragGestures { change, dragAmount ->
                             change.consume()
-                            val y = dragAmount // .y 제거
+                            val y = dragAmount
                             if (y < -10 && isCalendarExpanded) {
                                 isCalendarExpanded = false
                             } else if (y > 10 && !isCalendarExpanded) {
@@ -215,7 +230,6 @@ fun ScheduleScreen(
                     }
             ) {
                 if (isCalendarExpanded) {
-                    // --- 디자인 B (상세 뷰) ---
                     DetailedCalendarMonthView(
                         selectedDate = selectedDate.dayOfMonth,
                         onDateClick = viewModel::onDateSelected,
@@ -223,7 +237,6 @@ fun ScheduleScreen(
                         monthSchedules = monthSchedules
                     )
                 } else {
-                    // --- 디자인 A (심플 뷰) ---
                     SimpleCalendarMonthView(
                         selectedDate = selectedDate.dayOfMonth,
                         onDateClick = viewModel::onDateSelected,
@@ -233,32 +246,26 @@ fun ScheduleScreen(
                 }
             }
 
-            // --- 2. 구분선 ---
             Divider(color = Color.Gray.copy(alpha = 0.1f), thickness = 8.dp)
 
-            // --- 3. 하단 일정 목록 (LazyColumn) ---
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color.White)
             ) {
-
                 item {
                     DayHeader(selectedDate = selectedDate)
                 }
-
-                // ★★★ (수정) 목록 로직 변경 ---
                 if (schedules.isEmpty()) {
                     item {
                         Box(
                             modifier = Modifier.fillMaxWidth().padding(vertical = 80.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            Text("등록된 일정이 없습니다.", fontSize = 16.sp, color = Color.Gray)
+                            Text("등록된 일정이 없습니다", fontSize = 16.sp, color = Color.Gray)
                         }
                     }
                 } else {
-                    // 1. '하루 종일' 일정
                     val allDaySchedules = schedules.filter { it.isAllDay }
                     items(allDaySchedules, key = { "all-day-${it.id}" }) { schedule ->
                         AllDayScheduleItem(
@@ -268,15 +275,10 @@ fun ScheduleScreen(
                             }
                         )
                     }
-
-                    // 2. '시간 지정' 일정
                     val timedSchedules = schedules.filter { !it.isAllDay }
-
-                    // '하루 종일'과 '시간 지정' 사이에 간격
                     if (allDaySchedules.isNotEmpty() && timedSchedules.isNotEmpty()) {
                         item { Spacer(modifier = Modifier.height(8.dp)) }
                     }
-
                     items(timedSchedules, key = { "timed-${it.id}" }) { schedule ->
                         DayScheduleItem(
                             schedule = schedule,
@@ -290,10 +292,8 @@ fun ScheduleScreen(
                         )
                     }
                 }
-                // ★★★ (수정 끝) ---
-
                 item {
-                    Spacer(modifier = Modifier.height(100.dp)) // FAB 여백
+                    Spacer(modifier = Modifier.height(100.dp))
                 }
             }
         }
@@ -305,7 +305,7 @@ fun ScheduleScreen(
 // Composable 함수들
 // ======================================================================
 
-// --- 디자인 A (심플 뷰: 선 표시) ---
+// --- (기존) SimpleCalendarMonthView (변경 없음) ---
 @Composable
 fun SimpleCalendarMonthView(
     selectedDate: Int,
@@ -349,7 +349,7 @@ fun SimpleCalendarMonthView(
                     Box(
                         modifier = Modifier
                             .weight(1f)
-                            .height(50.dp), // 셀의 고정 높이
+                            .height(50.dp),
                         contentAlignment = Alignment.TopCenter
                     ) {
                         if (day != null) {
@@ -369,7 +369,6 @@ fun SimpleCalendarMonthView(
                                     .padding(vertical = 4.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
-                                // 1. 날짜 텍스트
                                 Box(
                                     modifier = Modifier
                                         .size(28.dp)
@@ -385,13 +384,11 @@ fun SimpleCalendarMonthView(
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(4.dp))
-
-                                // 2. 일정 표시 선 (최대 2개)
                                 Column(
                                     horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                                    verticalArrangement = Arrangement.spacedBy(1.dp)
                                 ) {
-                                    schedulesForDay.take(2).forEach { schedule ->
+                                    schedulesForDay.forEach { schedule ->
                                         val indicatorColor = try {
                                             Color(android.graphics.Color.parseColor(schedule.color))
                                         } catch (e: Exception) { Color.Gray }
@@ -422,7 +419,7 @@ fun SimpleCalendarMonthView(
 }
 
 
-// --- 디자인 B (상세 뷰: 텍스트 표시 + 구분선) ---
+// --- (기존) DetailedCalendarMonthView (변경 없음) ---
 @Composable
 fun DetailedCalendarMonthView(
     selectedDate: Int,
@@ -446,7 +443,6 @@ fun DetailedCalendarMonthView(
             .fillMaxWidth()
             .padding(vertical = 8.dp)
     ) {
-        // --- 1. 요일 헤더 ---
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -465,88 +461,74 @@ fun DetailedCalendarMonthView(
         }
         Spacer(modifier = Modifier.height(12.dp))
 
-        // --- 2. 날짜 그리드 ---
         Column {
             dates.forEach { week ->
-                // 각 주(week)가 시작하기 전에 구분선 추가
                 Divider(
                     color = Color.Gray.copy(alpha = 0.2f),
                     thickness = 1.dp
                 )
-
-                // --- 한 주의 날짜들 ---
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
                 ) {
                     week.forEach { day ->
-
-                        // ★★★ (수정) 날짜 셀 전체에 테두리 적용
                         val isSelected = day == selectedDate
                         val borderModifier = if (isSelected) {
                             Modifier.border(2.dp, Color(0xFF34A853), RoundedCornerShape(8.dp))
                         } else Modifier
 
-                        // 날짜 셀
                         Box(
                             modifier = Modifier
                                 .weight(1f)
-                                .heightIn(min = 80.dp) // 최소 높이
-                                .then(borderModifier) // ★★★ (수정) 테두리 적용
+                                .heightIn(min = 80.dp)
+                                .then(borderModifier)
                                 .clickable { if (day != null) onDateClick(day) }
                                 .padding(2.dp),
                             contentAlignment = Alignment.TopStart
                         ) {
                             if (day != null) {
                                 val schedulesForDay = monthSchedules[day] ?: emptyList()
-
                                 Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(vertical = 4.dp, horizontal = 2.dp),
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
-                                    // 1. 날짜 텍스트
                                     Text(
                                         text = day.toString(),
                                         fontSize = 14.sp,
                                         color = if (isSelected) Color(0xFF34A853) else Color.Black,
                                         fontWeight = FontWeight.SemiBold
                                     )
-                                    Spacer(modifier = Modifier.height(4.dp))
-
-                                    // 2. 일정 제목/선 표시
+                                    Spacer(modifier = Modifier.height(3.dp))
                                     Column(
-                                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                                        verticalArrangement = Arrangement.spacedBy(1.dp)
                                     ) {
-                                        schedulesForDay.filter { it.isAllDay }.take(2).forEach {
-                                            ScheduleTagItem(schedule = it) // '하루 종일' 일정
+                                        schedulesForDay.filter { it.isAllDay }.forEach {
+                                            ScheduleTagItem(schedule = it)
                                         }
-                                        schedulesForDay.filter { !it.isAllDay }.take(2).forEach {
-                                            ScheduleBarItem(schedule = it) // '시간 지정' 일정
+                                        schedulesForDay.filter { !it.isAllDay }.forEach {
+                                            ScheduleBarItem(schedule = it)
                                         }
                                     }
                                 }
                             }
-                        } // Box (날짜 셀)
-                    } // week.forEach 끝
+                        }
+                    }
 
-                    // (빈 칸 채우기)
                     if (week.size < 7) {
                         repeat(7 - week.size) {
                             Spacer(modifier = Modifier.weight(1f).heightIn(min = 80.dp))
                         }
                     }
-                } // Row 끝
-            } // dates.forEach 끝
-        } // Column 끝
+                }
+            }
+        }
     }
 }
 
-/**
- * '하루 종일' 일정을 위한 태그(Tag) Composable
- */
+// --- (기존) ScheduleTagItem (변경 없음, 9sp / 1.dp) ---
 @Composable
 private fun ScheduleTagItem(schedule: Schedule) {
     val scheduleColor = try {
@@ -557,11 +539,11 @@ private fun ScheduleTagItem(schedule: Schedule) {
         modifier = Modifier
             .fillMaxWidth()
             .background(scheduleColor.copy(alpha = 0.3f), RoundedCornerShape(4.dp))
-            .padding(horizontal = 4.dp, vertical = 2.dp)
+            .padding(horizontal = 4.dp, vertical = 1.dp)
     ) {
         Text(
             text = schedule.title,
-            fontSize = 10.sp,
+            fontSize = 9.sp,
             color = scheduleColor.copy(alpha = 0.9f),
             fontWeight = FontWeight.Medium,
             maxLines = 1,
@@ -570,9 +552,7 @@ private fun ScheduleTagItem(schedule: Schedule) {
     }
 }
 
-/**
- * '시간 지정' 일정을 위한 바(Bar) Composable (시간 텍스트 제거)
- */
+// --- (기존) ScheduleBarItem (변경 없음, 12.dp / 9.sp) ---
 @Composable
 private fun ScheduleBarItem(schedule: Schedule) {
     val scheduleColor = try {
@@ -586,14 +566,14 @@ private fun ScheduleBarItem(schedule: Schedule) {
         Box(
             modifier = Modifier
                 .width(3.dp)
-                .height(14.dp)
+                .height(12.dp)
                 .background(scheduleColor, RoundedCornerShape(2.dp))
         )
         Spacer(modifier = Modifier.width(4.dp))
 
         Text(
             text = schedule.title,
-            fontSize = 10.sp,
+            fontSize = 9.sp,
             color = Color.Black,
             fontWeight = FontWeight.Medium,
             maxLines = 1,
@@ -603,51 +583,30 @@ private fun ScheduleBarItem(schedule: Schedule) {
 }
 
 
-// --- 캘린더 헤더 ---
+// ★★★ 7. (수정) 캘린더 헤더 (텍스트 전용)
 @Composable
 fun CalendarHeader(
     yearMonth: String,
     modifier: Modifier = Modifier,
-    onPrevClick: () -> Unit,
-    onNextClick: () -> Unit,
     onMonthArrowClick: () -> Unit
 ) {
     Row(
         modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+            .clickable { onMonthArrowClick() }
+            .padding(horizontal = 16.dp), // 클릭 영역 확보
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        IconButton(onClick = onPrevClick) {
-            Icon(Icons.Default.ArrowBackIosNew, "이전 달", modifier = Modifier.size(18.dp))
-        }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .clickable { onMonthArrowClick() }
-                .padding(horizontal = 16.dp)
-        ) {
-            Text(
-                text = yearMonth,
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black
-            )
-            Spacer(modifier = Modifier.width(6.dp))
-            Icon(
-                imageVector = Icons.Default.KeyboardArrowDown,
-                contentDescription = "월 변경",
-                modifier = Modifier.size(20.dp)
-            )
-        }
-        IconButton(onClick = onNextClick) {
-            Icon(Icons.Default.ArrowForwardIos, "다음 달", modifier = Modifier.size(18.dp))
-        }
+        Text(
+            text = yearMonth,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black,
+            textAlign = TextAlign.Center
+        )
     }
 }
 
-// --- "XX일 X요일" 헤더 ---
+// --- (기존) DayHeader (변경 없음) ---
 @Composable
 fun DayHeader(selectedDate: LocalDate) {
     val dayOfMonth = selectedDate.dayOfMonth
@@ -672,7 +631,7 @@ fun DayHeader(selectedDate: LocalDate) {
     }
 }
 
-// --- 일정 아이템 (하단 목록용 - '시간 지정' 전용) ---
+// --- (기존) DayScheduleItem (변경 없음) ---
 @Composable
 fun DayScheduleItem(
     schedule: Schedule,
@@ -681,7 +640,6 @@ fun DayScheduleItem(
 ) {
     val zoneId = ZoneId.systemDefault()
 
-    // '하루 종일' 체크는 이제 상위에서 필터링되므로, 항상 시간 표시
     val startTimeString = schedule.startDate.toDate().toInstant()
         .atZone(zoneId)
         .format(DateTimeFormatter.ofPattern("H:mm"))
@@ -695,8 +653,6 @@ fun DayScheduleItem(
         Color(android.graphics.Color.parseColor(schedule.color))
     } catch (e: Exception) { Color.Black }
 
-    // val hasPet = schedule.petNames.isNotEmpty() // OverlappingPetIcons가 알아서 처리
-
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -706,7 +662,7 @@ fun DayScheduleItem(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = startTimeString, // '종일' 텍스트가 필요 없음
+            text = startTimeString,
             fontSize = 14.sp,
             fontWeight = FontWeight.Medium,
             color = Color.Gray,
@@ -735,8 +691,6 @@ fun DayScheduleItem(
             )
         }
         Spacer(modifier = Modifier.width(16.dp))
-
-        // ★★★ (수정) 펫 아이콘을 새 컴포저블로 대체
         OverlappingPetIcons(
             petNames = schedule.petNames,
             color = scheduleColor
@@ -744,7 +698,7 @@ fun DayScheduleItem(
     }
 }
 
-// --- ★★★ (신규) '하루 종일' 일정 아이템 ---
+// --- (기존) AllDayScheduleItem (변경 없음) ---
 @Composable
 fun AllDayScheduleItem(
     schedule: Schedule,
@@ -755,27 +709,25 @@ fun AllDayScheduleItem(
         Color(android.graphics.Color.parseColor(schedule.color))
     } catch (e: Exception) { Color.Black }
 
-    // 선택한 색상의 연한 버전
     val lightBackgroundColor = scheduleColor.copy(alpha = 0.2f)
 
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 6.dp) // 리스트 항목 간 패딩
+            .padding(horizontal = 20.dp, vertical = 6.dp)
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = lightBackgroundColor),
-        elevation = CardDefaults.cardElevation(0.dp) // 그림자 제거
+        elevation = CardDefaults.cardElevation(0.dp)
     ) {
         Row(
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // 캘린더 아이콘 (사진 참조)
             Icon(
-                imageVector = Icons.Filled.Event, // 캘린더 모양 아이콘
+                imageVector = Icons.Filled.Event,
                 contentDescription = "하루 종일",
-                tint = scheduleColor // 아이콘은 진한 색상
+                tint = scheduleColor
             )
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {
@@ -783,7 +735,7 @@ fun AllDayScheduleItem(
                     text = schedule.title,
                     fontSize = 16.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color.Black.copy(alpha = 0.8f) // 너무 진하지 않게
+                    color = Color.Black.copy(alpha = 0.8f)
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
@@ -792,7 +744,6 @@ fun AllDayScheduleItem(
                     color = Color.Gray
                 )
             }
-            // 펫 아이콘 (겹치는)
             OverlappingPetIcons(
                 petNames = schedule.petNames,
                 color = scheduleColor
@@ -802,7 +753,7 @@ fun AllDayScheduleItem(
 }
 
 
-// --- ★★★ (신규) 겹치는 펫 아이콘 ---
+// --- (기존) OverlappingPetIcons (변경 없음) ---
 @Composable
 fun OverlappingPetIcons(
     petNames: List<String>,
@@ -810,36 +761,32 @@ fun OverlappingPetIcons(
     modifier: Modifier = Modifier
 ) {
     if (petNames.isEmpty()) {
-        Spacer(modifier = modifier.width(40.dp)) // 펫이 없으면 공간만 차지
+        Spacer(modifier = modifier.width(40.dp))
         return
     }
 
     Box(
         modifier = modifier
-            // 펫이 2개 이상이면 64dp, 1개면 40dp
             .width(if (petNames.size > 1) 64.dp else 40.dp)
             .height(40.dp),
         contentAlignment = Alignment.CenterStart
     ) {
-        // Icon 2 (오른쪽, 뒤에)
         if (petNames.size > 1) {
             PetIconCircle(
                 petName = petNames[1],
-                color = color.copy(alpha = 0.7f), // 뒤에 아이콘은 살짝 연하게
-                modifier = Modifier.padding(start = 24.dp) // 24dp 겹치게
+                color = color.copy(alpha = 0.7f),
+                modifier = Modifier.padding(start = 24.dp)
             )
         }
-
-        // Icon 1 (왼쪽, 위에)
         PetIconCircle(
             petName = petNames[0],
             color = color,
-            modifier = Modifier // ★★★ (수정) 흰색 테두리(border) 제거
+            modifier = Modifier
         )
     }
 }
 
-// --- ★★★ (신규) 펫 아이콘 원형 헬퍼 ---
+// --- (기존) PetIconCircle (변경 없음) ---
 @Composable
 private fun PetIconCircle(petName: String, color: Color, modifier: Modifier = Modifier) {
     Box(
@@ -859,7 +806,7 @@ private fun PetIconCircle(petName: String, color: Color, modifier: Modifier = Mo
 }
 
 
-// --- 월/년 선택 다이얼로그 ---
+// --- (기존) MonthYearPickerDialog (변경 없음) ---
 @Composable
 fun MonthYearPickerDialog(
     initialYear: Int,
@@ -913,7 +860,7 @@ fun MonthYearPickerDialog(
     )
 }
 
-// --- 미리보기 ---
+// --- (기존) Preview (변경 없음) ---
 @Preview(showBackground = true, widthDp = 360, heightDp = 740)
 @Composable
 fun ScheduleScreenPreview() {

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleViewModel.kt
@@ -11,7 +11,6 @@ import com.google.firebase.firestore.toObjects
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import java.time.LocalDate
@@ -19,91 +18,73 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.util.Date
 
+// ★★★ (신규) 3가지 삭제 유형을 정의하는 Enum 클래스
+enum class DeletionType {
+    SINGLE, // 이 일정만
+    FUTURE, // 이 일정 + 미래
+    ALL     // 모든 관련 일정
+}
+
 class ScheduleViewModel : ViewModel() {
 
     private val db = Firebase.firestore
-    private val zoneId = ZoneId.systemDefault() // zoneId를 멤버 변수로 선언
+    private val zoneId = ZoneId.systemDefault()
 
-    // --- 1. 기존 상태 (선택된 날짜, 현재 월, 선택된 날의 일정 목록) ---
+    // --- (기존 상태 - 변경 없음) ---
     private val _selectedDate = MutableStateFlow(LocalDate.now())
     val selectedDate = _selectedDate.asStateFlow()
-
     private val _currentMonth = MutableStateFlow(YearMonth.now())
     val currentMonth = _currentMonth.asStateFlow()
-
     private val _schedules = MutableStateFlow<List<Schedule>>(emptyList())
-    val schedules = _schedules.asStateFlow() // 하단 목록용
-
-    // --- ★ 2. (신규) 캘린더 UI(색상 선)를 위한 현재 '월'의 전체 일정 ---
+    val schedules = _schedules.asStateFlow()
     private val _monthSchedules = MutableStateFlow<Map<Int, List<Schedule>>>(emptyMap())
-    val monthSchedules = _monthSchedules.asStateFlow() // 캘린더 인디케이터용
-
-    // --- 3. (기존) 일정 상세보기용 상태 ---
+    val monthSchedules = _monthSchedules.asStateFlow()
     private val _selectedSchedule = MutableStateFlow<Schedule?>(null)
     val selectedSchedule = _selectedSchedule.asStateFlow()
 
     init {
-        // 앱 시작 시, 1. 선택된 날짜의 목록 / 2. 현재 월의 전체 일정을 모두 불러옴
         fetchSchedulesForDate(_selectedDate.value)
-        loadMonthSchedules(_currentMonth.value) // ★ 신규 호출
+        loadMonthSchedules(_currentMonth.value)
     }
 
-    /**
-     * 날짜를 클릭했을 때 호출 (기존과 동일)
-     * _schedules (하단 목록)만 업데이트
-     */
+    // --- (기존 함수 - 변경 없음) ---
     fun onDateSelected(day: Int) {
         val newDate = _currentMonth.value.atDay(day)
         _selectedDate.value = newDate
         fetchSchedulesForDate(newDate)
     }
 
-    /**
-     * 이전/다음 달 버튼 클릭 (★ 수정됨)
-     */
     fun onMonthChange(isNext: Boolean) {
         val newMonth = if (isNext) _currentMonth.value.plusMonths(1) else _currentMonth.value.minusMonths(1)
         _currentMonth.value = newMonth
-
-        loadMonthSchedules(newMonth) // ★ 신규: 월 전체 일정을 새로고침
-        onDateSelected(1)          // ★ 추가: 1일을 기본으로 선택
+        loadMonthSchedules(newMonth)
+        onDateSelected(1)
     }
 
-    /**
-     * 월/년 픽커에서 선택 (★ 수정됨)
-     */
     fun onMonthYearChange(year: Int, month: Int) {
         val newYearMonth = YearMonth.of(year, month)
         _currentMonth.value = newYearMonth
-
-        loadMonthSchedules(newYearMonth) // ★ 신규: 월 전체 일정을 새로고침
-
-        // (기존 로직 유지 - 선택한 '일'을 보존하려는 좋은 로직)
+        loadMonthSchedules(newYearMonth)
         val currentDay = _selectedDate.value.dayOfMonth
         val maxDayInNewMonth = newYearMonth.lengthOfMonth()
         val newDay = currentDay.coerceAtMost(maxDayInNewMonth)
         onDateSelected(newDay)
     }
 
-    /**
-     * [선택된 날짜]의 일정만 불러오기 (기존과 동일)
-     * (하단 목록을 채우는 용도)
-     */
     private fun fetchSchedulesForDate(date: LocalDate) {
         viewModelScope.launch {
             try {
                 val startOfDay = date.atStartOfDay(zoneId)
-                val endOfDay = date.plusDays(1).atStartOfDay(zoneId) // 다음 날 0시
+                val endOfDay = date.plusDays(1).atStartOfDay(zoneId)
                 val startTimestamp = Timestamp(Date.from(startOfDay.toInstant()))
                 val endTimestamp = Timestamp(Date.from(endOfDay.toInstant()))
 
                 val querySnapshot = db.collection("schedules")
                     .whereGreaterThanOrEqualTo("startDate", startTimestamp)
-                    .whereLessThan("startDate", endTimestamp) // endOfDay 미만
+                    .whereLessThan("startDate", endTimestamp)
                     .orderBy("startDate")
                     .get()
                     .await()
-
                 _schedules.value = querySnapshot.toObjects<Schedule>()
             } catch (e: Exception) {
                 Log.e("ScheduleVM", "선택일 일정 로드 실패", e)
@@ -112,22 +93,14 @@ class ScheduleViewModel : ViewModel() {
         }
     }
 
-    /**
-     * ★★★ (신규) [현재 월]의 전체 일정을 불러오기
-     * (캘린더의 색상 선을 채우는 용도)
-     */
     private fun loadMonthSchedules(yearMonth: YearMonth) {
         viewModelScope.launch {
             try {
-                // 1. 현재 월의 시작 (1일 00:00)
                 val startOfMonth = yearMonth.atDay(1).atStartOfDay(zoneId)
-                // 2. 다음 달의 시작 (다음 달 1일 00:00)
                 val startOfNextMonth = yearMonth.plusMonths(1).atDay(1).atStartOfDay(zoneId)
-
                 val startTimestamp = Timestamp(Date.from(startOfMonth.toInstant()))
-                val endTimestamp = Timestamp(Date.from(startOfNextMonth.toInstant())) // (쿼리용)
+                val endTimestamp = Timestamp(Date.from(startOfNextMonth.toInstant()))
 
-                // 3. 'startDate'가 이번 달 1일 00:00 ~ 다음 달 1일 00:00 "미만"인 일정
                 val querySnapshot = db.collection("schedules")
                     .whereGreaterThanOrEqualTo("startDate", startTimestamp)
                     .whereLessThan("startDate", endTimestamp)
@@ -135,42 +108,34 @@ class ScheduleViewModel : ViewModel() {
                     .await()
 
                 val schedulesList = querySnapshot.toObjects<Schedule>()
-
-                // 4. List<Schedule> -> Map<Int, List<Schedule>>로 가공
                 val groupedSchedules = schedulesList
                     .groupBy { schedule ->
-                        // startDate의 '일(day)'을 기준으로 그룹화
                         schedule.startDate.toDate().toInstant()
                             .atZone(zoneId)
                             .toLocalDate()
                             .dayOfMonth
                     }
-
                 _monthSchedules.value = groupedSchedules
                 Log.d("ScheduleVM", "월간 일정(${yearMonth}) 로드 성공")
-
             } catch (e: Exception) {
                 Log.e("ScheduleVM", "월간 일정 로드 실패", e)
-                _monthSchedules.value = emptyMap() // 실패 시 비워줌
+                _monthSchedules.value = emptyMap()
             }
         }
     }
 
-    // (기존) 시간 변환 함수
     fun getHourFromTimestamp(timestamp: Timestamp): Int {
         val instant = timestamp.toDate().toInstant()
         return instant.atZone(zoneId).hour
     }
 
-    // (기존) 일정 상세 로드 함수
     fun loadScheduleDetails(scheduleId: String?) {
         if (scheduleId == null || scheduleId == "temp_id") {
             Log.e("ScheduleViewModel", "유효하지 않은 scheduleId: $scheduleId")
             _selectedSchedule.value = null
             return
         }
-        _selectedSchedule.value = null // 로딩 시작
-
+        _selectedSchedule.value = null
         viewModelScope.launch {
             try {
                 val document = db.collection("schedules").document(scheduleId).get().await()
@@ -182,35 +147,62 @@ class ScheduleViewModel : ViewModel() {
         }
     }
 
-    /**
-     * 일정 삭제 함수 (★ 수정됨)
-     */
-    fun deleteSchedule(scheduleId: String, onComplete: () -> Unit) {
-        if (scheduleId.isBlank() || scheduleId == "temp_id") {
-            Log.e("ScheduleViewModel", "유효하지 않은 ID로 삭제를 시도했습니다: $scheduleId")
+    // ★★★ (대폭 수정) 일정 삭제 함수 ★★★
+    fun deleteSchedule(deletionType: DeletionType, onComplete: () -> Unit) {
+        val schedule = _selectedSchedule.value
+        if (schedule == null) {
+            Log.e("ScheduleViewModel", "삭제할 일정이 선택되지 않았습니다.")
             return
         }
 
         viewModelScope.launch {
             try {
-                db.collection("schedules").document(scheduleId).delete().await()
-                Log.d("ScheduleViewModel", "일정 삭제 성공: $scheduleId")
+                when (deletionType) {
+                    DeletionType.SINGLE -> {
+                        // 1. 단일 일정 삭제 (기존 로직)
+                        db.collection("schedules").document(schedule.id).delete().await()
+                        Log.d("ScheduleViewModel", "단일 일정 삭제 성공: ${schedule.id}")
+                    }
 
-                // (추가) 목록 화면 갱신
+                    // "이후 일정" 또는 "모든 일정"은 쿼리가 필요함
+                    DeletionType.FUTURE, DeletionType.ALL -> {
+                        // "반복 안 함" 일정이면 단일 삭제와 동일하게 처리
+                        if (schedule.recurrenceRule == "반복 안 함") {
+                            db.collection("schedules").document(schedule.id).delete().await()
+                            Log.d("ScheduleViewModel", "반복 없는 일정, 단일 삭제: ${schedule.id}")
+                        } else {
+                            // 쿼리 기준: 제목과 반복 규칙이 같아야 함 (가장 중요)
+                            var query = db.collection("schedules")
+                                .whereEqualTo("title", schedule.title)
+                                .whereEqualTo("recurrenceRule", schedule.recurrenceRule)
+
+                            // "이후"일 경우에만 시간 필터 추가
+                            if (deletionType == DeletionType.FUTURE) {
+                                query = query.whereGreaterThanOrEqualTo("startDate", schedule.startDate)
+                            }
+
+                            val querySnapshot = query.get().await()
+                            val batch = db.batch()
+                            querySnapshot.documents.forEach { doc ->
+                                batch.delete(doc.reference)
+                            }
+                            batch.commit().await()
+                            Log.d("ScheduleViewModel", "${querySnapshot.size()}개 반복 일정(${deletionType}) 삭제 성공")
+                        }
+                    }
+                }
+
+                // (공통 로직) 목록 및 캘린더 새로고침
                 fetchSchedulesForDate(_selectedDate.value)
-                // (★★★ 신규) 캘린더(색상 선)도 갱신
                 loadMonthSchedules(_currentMonth.value)
-
                 onComplete()
+
             } catch (e: Exception) {
                 Log.e("ScheduleViewModel", "일정 삭제 실패", e)
             }
         }
     }
 
-    /**
-     * ★★★ (신규) 일정 생성/수정 후 ScheduleScreen에서 호출할 새로고침 함수
-     */
     fun refreshAllSchedules() {
         Log.d("ScheduleVM", "모든 일정 새로고침 (목록 + 월간 캘린더)")
         fetchSchedulesForDate(_selectedDate.value)

--- a/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/schedule/ScheduleViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.howsu.data.model.Schedule
 import com.google.firebase.Timestamp
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.toObject
 import com.google.firebase.firestore.toObjects
@@ -72,6 +73,13 @@ class ScheduleViewModel : ViewModel() {
     }
 
     private fun fetchSchedulesForDate(date: LocalDate) {
+        val currentUser = Firebase.auth.currentUser
+        if (currentUser == null) {
+            _schedules.value = emptyList()
+            return
+        }
+        val currentFamilyId = currentUser.uid // ★ 내 아이디 가져오기
+
         viewModelScope.launch {
             try {
                 val startOfDay = date.atStartOfDay(zoneId)
@@ -80,6 +88,7 @@ class ScheduleViewModel : ViewModel() {
                 val endTimestamp = Timestamp(Date.from(endOfDay.toInstant()))
 
                 val querySnapshot = db.collection("schedules")
+                    .whereEqualTo("familyId", currentFamilyId) // ★ [필수] 내 가족(나)의 일정만
                     .whereGreaterThanOrEqualTo("startDate", startTimestamp)
                     .whereLessThan("startDate", endTimestamp)
                     .orderBy("startDate")
@@ -94,6 +103,10 @@ class ScheduleViewModel : ViewModel() {
     }
 
     private fun loadMonthSchedules(yearMonth: YearMonth) {
+        val currentUser = Firebase.auth.currentUser
+        if (currentUser == null) return
+        val currentFamilyId = currentUser.uid
+
         viewModelScope.launch {
             try {
                 val startOfMonth = yearMonth.atDay(1).atStartOfDay(zoneId)
@@ -102,6 +115,7 @@ class ScheduleViewModel : ViewModel() {
                 val endTimestamp = Timestamp(Date.from(startOfNextMonth.toInstant()))
 
                 val querySnapshot = db.collection("schedules")
+                    .whereEqualTo("familyId", currentFamilyId) // ★ [필수]
                     .whereGreaterThanOrEqualTo("startDate", startTimestamp)
                     .whereLessThan("startDate", endTimestamp)
                     .get()
@@ -149,34 +163,27 @@ class ScheduleViewModel : ViewModel() {
 
     // ★★★ (대폭 수정) 일정 삭제 함수 ★★★
     fun deleteSchedule(deletionType: DeletionType, onComplete: () -> Unit) {
-        val schedule = _selectedSchedule.value
-        if (schedule == null) {
-            Log.e("ScheduleViewModel", "삭제할 일정이 선택되지 않았습니다.")
-            return
-        }
+        val schedule = _selectedSchedule.value ?: return
+
+        // ★ 안전장치: 현재 로그인한 사람 확인
+        val currentUser = Firebase.auth.currentUser ?: return
+        val currentFamilyId = currentUser.uid
 
         viewModelScope.launch {
             try {
                 when (deletionType) {
                     DeletionType.SINGLE -> {
-                        // 1. 단일 일정 삭제 (기존 로직)
                         db.collection("schedules").document(schedule.id).delete().await()
-                        Log.d("ScheduleViewModel", "단일 일정 삭제 성공: ${schedule.id}")
                     }
-
-                    // "이후 일정" 또는 "모든 일정"은 쿼리가 필요함
                     DeletionType.FUTURE, DeletionType.ALL -> {
-                        // "반복 안 함" 일정이면 단일 삭제와 동일하게 처리
                         if (schedule.recurrenceRule == "반복 안 함") {
                             db.collection("schedules").document(schedule.id).delete().await()
-                            Log.d("ScheduleViewModel", "반복 없는 일정, 단일 삭제: ${schedule.id}")
                         } else {
-                            // 쿼리 기준: 제목과 반복 규칙이 같아야 함 (가장 중요)
                             var query = db.collection("schedules")
+                                .whereEqualTo("familyId", currentFamilyId) // ★ [중요] 내 일정 중에서만 검색
                                 .whereEqualTo("title", schedule.title)
                                 .whereEqualTo("recurrenceRule", schedule.recurrenceRule)
 
-                            // "이후"일 경우에만 시간 필터 추가
                             if (deletionType == DeletionType.FUTURE) {
                                 query = query.whereGreaterThanOrEqualTo("startDate", schedule.startDate)
                             }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/setting/SettingScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/setting/SettingScreen.kt
@@ -1,0 +1,258 @@
+package com.example.howsu.screen.setting
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import com.example.howsu.screen.login.AuthViewModel
+
+@Composable
+fun SettingScreen(
+    navController: NavHostController,
+    authViewModel: AuthViewModel = viewModel()
+
+) {
+    var showLogoutDialog by remember { mutableStateOf(false) }
+    var showWithdrawDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = { SettingTopBar(onBackClick = { navController.popBackStack() }) }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+        ) {
+            SettingNotificationRow()
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            SettingAccountSection(
+                onLogoutClick = { showLogoutDialog = true },
+                onWithdrawClick = { showWithdrawDialog = true }
+            )
+        }
+    }
+
+    if (showLogoutDialog) {
+        ConfirmationDialog(
+            title = "로그아웃",
+            text = "로그아웃 하시겠어요?",
+            confirmText = "로그아웃",
+            onConfirm = {
+                authViewModel.signOut()
+                showLogoutDialog = false
+                navController.navigate("login") {
+                    popUpTo(navController.graph.id) {
+                        inclusive = true
+                    }
+                }
+            },
+            onDismiss = { showLogoutDialog = false }
+        )
+    }
+
+    if (showWithdrawDialog) {
+        ConfirmationDialog(
+            title = "회원 탈퇴",
+            text = "정말 탈퇴하시겠어요?",
+            confirmText = "회원 탈퇴",
+            onConfirm = {
+                authViewModel.deleteUserAndLogout()
+                showWithdrawDialog = false
+                navController.navigate("login") {
+                    popUpTo(navController.graph.id) {
+                        inclusive = true
+                    }
+                }
+            },
+            onDismiss = { showWithdrawDialog = false }
+        )
+    }
+}
+
+// --- 공통 컴포저블 ---
+
+@Composable
+private fun SettingTopBar(onBackClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .height(40.dp)
+    ) {
+        IconButton(
+            onClick = onBackClick,
+            modifier = Modifier
+                .size(39.dp)
+                .align(Alignment.CenterStart)
+        ) {
+            Icon(Icons.Default.ArrowBack, "뒤로가기", modifier = Modifier.size(24.dp))
+        }
+        Text(
+            "설정",
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+@Composable
+private fun SettingNotificationRow() {
+    val customSwitchColors = SwitchDefaults.colors(
+        checkedTrackColor = Color.Black,
+        checkedThumbColor = Color.White,
+        uncheckedTrackColor = Color.LightGray,
+        uncheckedThumbColor = Color.White,
+        uncheckedBorderColor = Color.LightGray,
+        disabledCheckedTrackColor = Color.Black,
+        disabledCheckedThumbColor = Color.White,
+        disabledUncheckedTrackColor = Color.LightGray,
+        disabledUncheckedThumbColor = Color.White,
+        disabledUncheckedBorderColor = Color.LightGray
+    )
+
+    var isChecked by remember { mutableStateOf(true) }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { isChecked = !isChecked }
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .height(40.dp)
+    ) {
+        Text(
+            text = "알림",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.weight(1f)
+        )
+        Switch(
+            checked = isChecked,
+            onCheckedChange = { isChecked = it },
+            modifier = Modifier.scale(0.8f),
+            colors = customSwitchColors
+        )
+    }
+}
+
+@Composable
+private fun SettingAccountSection(
+    onLogoutClick: () -> Unit,
+    onWithdrawClick: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        // '계정' 섹션 헤더 - 16sp, Bold
+        Text(
+            text = "계정",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+
+        SettingMenuItem(label = "로그아웃", onClick = onLogoutClick)
+        SettingMenuItem(label = "회원 탈퇴", onClick = onWithdrawClick)
+    }
+}
+
+@Composable
+private fun SettingMenuItem(label: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Text(
+            text = label,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+
+        IconButton(onClick = onClick) {
+            Icon(
+                Icons.Default.KeyboardArrowRight,
+                contentDescription = "이동",
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+@Composable
+private fun ConfirmationDialog(
+    title: String,
+    text: String,
+    confirmText: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(title)
+        },
+        text = {
+            Text(text)
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = if (confirmText.contains("탈퇴")) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text(confirmText)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("취소")
+            }
+        }
+    )
+}

--- a/Howsu/app/src/main/java/com/example/howsu/screen/setting/SettingScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/setting/SettingScreen.kt
@@ -76,8 +76,8 @@ fun SettingScreen(
             onConfirm = {
                 authViewModel.signOut()
                 showLogoutDialog = false
-                navController.navigate("login") {
-                    popUpTo(navController.graph.id) {
+                navController.navigate("auth_graph") {
+                    popUpTo(0) {
                         inclusive = true
                     }
                 }
@@ -94,8 +94,8 @@ fun SettingScreen(
             onConfirm = {
                 authViewModel.deleteUserAndLogout()
                 showWithdrawDialog = false
-                navController.navigate("login") {
-                    popUpTo(navController.graph.id) {
+                navController.navigate("auth_graph") {
+                    popUpTo(0) {
                         inclusive = true
                     }
                 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
@@ -155,7 +155,7 @@ private fun CreateTodoTopBar(onCloseClick: () -> Unit) {
         )
         IconButton(
             onClick = onCloseClick,
-            modifier = Modifier
+            modifier = Modifier.fillMaxWidth()
                 .size(39.dp)
                 .align(Alignment.CenterEnd)
                 .border(

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
@@ -1,9 +1,10 @@
 package com.example.howsu.screen.todo
 
-// --- (필요한 Import) ---
-
-import androidx.compose.foundation.BorderStroke
+// import androidx.compose.foundation.border // ★ 1. (삭제) border 임포트
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -48,12 +49,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
@@ -62,6 +67,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.times
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -69,86 +75,139 @@ import com.example.howsu.R
 import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.data.model.Pet
 import com.example.howsu.ui.theme.HowsuTheme
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-// --- 1. 메인 화면: Scaffold 뼈대 (ViewModel 주입) ---
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateTodoScreen(
     navController: NavHostController,
-    viewModel: CreateTodoViewModel = viewModel()
+    viewModel: CreateTodoViewModel = viewModel(),
+    documentId: String? = null
 ) {
-    // ViewModel의 State들을 수집(collect)
+    // --- (기존 State 구독) ---
     val familyMembers by viewModel.familyMembers.collectAsState()
     val selectedMember by viewModel.selectedMember.collectAsState()
     val taskTitle by viewModel.taskTitle.collectAsState()
-    val selectedDate by viewModel.selectedDate.collectAsState() // Long 타입
+    val selectedDate by viewModel.selectedDate.collectAsState()
     val isDatePickerVisible by viewModel.isDatePickerVisible.collectAsState()
     val allPets by viewModel.allPets.collectAsState()
     val selectedPets by viewModel.selectedPets.collectAsState()
     val isPetDropdownVisible by viewModel.isPetDropdownVisible.collectAsState()
+    val isEditMode by viewModel.isEditMode.collectAsState()
+
+    // --- (기존 쉐이크 애니메이션) ---
+    val scope = rememberCoroutineScope()
+    val shakeOffset = remember { Animatable(0f) }
+    fun triggerShake() {
+        scope.launch {
+            shakeOffset.animateTo(0f)
+            repeat(3) {
+                shakeOffset.animateTo(15f, tween(50))
+                shakeOffset.animateTo(-15f, tween(50))
+            }
+            shakeOffset.animateTo(0f, tween(50))
+        }
+    }
+
+    LaunchedEffect(key1 = documentId) {
+        viewModel.initialize(documentId)
+    }
+
+    // --- (기존 다이얼로그) ---
+    if (isDatePickerVisible) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate
+        )
+        DatePickerDialog(
+            onDismissRequest = viewModel::onDatePickerDismissed,
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.onDateSelected(datePickerState.selectedDateMillis)
+                }) { Text("확인") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::onDatePickerDismissed) { Text("취소") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             CreateTodoTopBar(
+                // ★★★ (수정) "할 일 수정하기"
+                title = if (isEditMode) "할 일 수정하기" else "투두 생성하기",
                 onCloseClick = { navController.popBackStack() }
             )
         },
-        bottomBar = {
+        // (기존) bottomBar 제거
+    ) { innerPadding ->
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            CreateTodoContent(
+                modifier = Modifier.fillMaxSize(),
+                isEditMode = isEditMode,
+                shakeOffset = shakeOffset.value,
+                familyMembers = familyMembers,
+                selectedMember = selectedMember,
+                taskTitle = taskTitle,
+                selectedDate = selectedDate,
+                isDatePickerVisible = isDatePickerVisible,
+                allPets = allPets,
+                selectedPets = selectedPets,
+                isPetDropdownVisible = isPetDropdownVisible,
+                onMemberSelected = viewModel::onMemberSelected,
+                onTaskTitleChanged = viewModel::onTaskTitleChanged,
+                onDatePickerClicked = viewModel::onDatePickerClicked,
+                onDateSelected = viewModel::onDateSelected,
+                onDatePickerDismissed = viewModel::onDatePickerDismissed,
+                onPetDropdownClicked = viewModel::onPetDropdownClicked,
+                onPetDropdownDismissed = viewModel::onPetDropdownDismissed,
+                onPetSelected = viewModel::onPetSelected,
+                onPetTagRemoved = viewModel::onPetTagRemoved
+            )
+
             CreateTodoBottomButton(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                // ★★★ (수정) "수정하기"로 변경
+                buttonText = if (isEditMode) "수정하기" else "투두 생성 완료",
                 onCreateClick = {
-                    viewModel.createTodo(
-                        onComplete = {
-                            navController.navigate("todo") { // 1. "todo" 스크린으로 이동
-                                popUpTo("create_todo") { // 2. 지금 화면("create_todo")은
-                                    inclusive = true       //    스택에서 포함해서 제거
-                                }
+                    if (taskTitle.isBlank()) {
+                        triggerShake()
+                    } else {
+                        viewModel.saveTodo(
+                            onComplete = {
+                                navController.popBackStack()
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             )
         }
-    ) { innerPadding ->
-        // Content에 모든 State와 이벤트 핸들러 전달
-        CreateTodoContent(
-            modifier = Modifier.padding(innerPadding),
-            familyMembers = familyMembers,
-            selectedMember = selectedMember,
-            taskTitle = taskTitle,
-            selectedDate = selectedDate, // Long 타입 전달
-            isDatePickerVisible = isDatePickerVisible,
-            allPets = allPets,
-            selectedPets = selectedPets,
-            isPetDropdownVisible = isPetDropdownVisible,
-            onMemberSelected = viewModel::onMemberSelected,
-            onTaskTitleChanged = viewModel::onTaskTitleChanged,
-            onDatePickerClicked = viewModel::onDatePickerClicked,
-            onDateSelected = viewModel::onDateSelected,
-            onDatePickerDismissed = viewModel::onDatePickerDismissed,
-            onPetDropdownClicked = viewModel::onPetDropdownClicked,
-            onPetDropdownDismissed = viewModel::onPetDropdownDismissed,
-            onPetSelected = viewModel::onPetSelected,
-            onPetTagRemoved = viewModel::onPetTagRemoved
-        )
     }
 }
 
-// --- 2. 상단 바 (변경 없음) ---
+// ★★★ 2. (수정) 상단 바 (X 버튼 테두리 제거) ★★★
 @Composable
-private fun CreateTodoTopBar(onCloseClick: () -> Unit) {
+private fun CreateTodoTopBar(title: String, onCloseClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .statusBarsPadding() // 상태 표시줄 띄워 주기
+            .statusBarsPadding()
             .padding(horizontal = 16.dp, vertical = 12.dp)
             .height(40.dp)
     ) {
         Text(
-            text = "투두 생성하기",
+            text = title,
             fontWeight = FontWeight.Bold,
             fontSize = 18.sp,
             modifier = Modifier.align(Alignment.Center)
@@ -158,10 +217,7 @@ private fun CreateTodoTopBar(onCloseClick: () -> Unit) {
             modifier = Modifier
                 .size(39.dp)
                 .align(Alignment.CenterEnd)
-                .border(
-                    BorderStroke(0.1.dp, Color.LightGray),
-                    CircleShape
-                )
+            // ★ (삭제) .border(...)
         ) {
             Icon(
                 imageVector = Icons.Default.Close,
@@ -172,13 +228,23 @@ private fun CreateTodoTopBar(onCloseClick: () -> Unit) {
     }
 }
 
-// --- 3. 하단 버튼 (변경 없음) ---
+// (기존) 하단 버튼 - 변경 없음
 @Composable
-private fun CreateTodoBottomButton(onCreateClick: () -> Unit) {
+private fun CreateTodoBottomButton(
+    buttonText: String,
+    modifier: Modifier = Modifier,
+    onCreateClick: () -> Unit
+) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = 60.dp)
+            .background(Color.Transparent)
+            .padding(
+                start = 24.dp,
+                end = 24.dp,
+                top = 16.dp,
+                bottom = 16.dp
+            )
     ) {
         Button(
             onClick = onCreateClick,
@@ -191,124 +257,12 @@ private fun CreateTodoBottomButton(onCreateClick: () -> Unit) {
             ),
             shape = RoundedCornerShape(12.dp)
         ) {
-            Text("투두 생성 완료", fontWeight = FontWeight.Medium, fontSize = 14.sp)
+            Text(buttonText, fontWeight = FontWeight.Medium, fontSize = 14.sp)
         }
     }
 }
 
-
-// --- 4. 본문 (스크롤 영역) (파라미터 타입 변경) ---
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
-@Composable
-private fun CreateTodoContent(
-    modifier: Modifier = Modifier,
-    familyMembers: List<FamilyMember>,
-    selectedMember: FamilyMember?,
-    taskTitle: String,
-    selectedDate: Long, // (변경) LocalDate -> Long
-    isDatePickerVisible: Boolean,
-    allPets: List<Pet>,
-    selectedPets: List<Pet>,
-    isPetDropdownVisible: Boolean,
-    onMemberSelected: (FamilyMember) -> Unit,
-    onTaskTitleChanged: (String) -> Unit,
-    onDatePickerClicked: () -> Unit,
-    onDateSelected: (Long?) -> Unit,
-    onDatePickerDismissed: () -> Unit,
-    onPetDropdownClicked: () -> Unit,
-    onPetDropdownDismissed: () -> Unit,
-    onPetSelected: (Pet) -> Unit,
-    onPetTagRemoved: (Pet) -> Unit
-) {
-    // 날짜 선택 다이얼로그
-    if (isDatePickerVisible) {
-        // ViewModel의 Long 값(selectedDate)을 초기값으로 설정
-        val datePickerState = rememberDatePickerState(
-            initialSelectedDateMillis = selectedDate
-        )
-        DatePickerDialog(
-            onDismissRequest = onDatePickerDismissed,
-            confirmButton = {
-                TextButton(onClick = {
-                    onDateSelected(datePickerState.selectedDateMillis)
-                }) {
-                    Text("확인")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = onDatePickerDismissed) {
-                    Text("취소")
-                }
-            }
-        ) {
-            DatePicker(state = datePickerState)
-        }
-    }
-
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        Spacer(modifier = Modifier.height(10.dp))
-
-        // 섹션 1: 누가 (변경 없음)
-        CreateTodoSection(
-            icon = rememberVectorPainter(image = Icons.Default.Person),
-            title = "누가"
-        ) {
-            AssigneeSelector(
-                members = familyMembers,
-                selectedMember = selectedMember,
-                onMemberSelected = onMemberSelected
-            )
-        }
-
-        // 섹션 2: 언제 (수정됨)
-        CreateTodoSection(
-            icon = painterResource(id = R.drawable.date_under),
-            title = "언제"
-        ) {
-            DatePickerField(
-                selectedDateMillis = selectedDate, // Long 값 전달
-                onClick = onDatePickerClicked
-            )
-        }
-
-        // 섹션 3: 해야 할 일 (변경 없음)
-        CreateTodoSection(
-            icon = rememberVectorPainter(image = Icons.Default.CheckBox),
-            title = "해야 할 일"
-        ) {
-            TaskTextField(
-                text = taskTitle,
-                onValueChange = onTaskTitleChanged
-            )
-        }
-
-        // 섹션 4: 반려동물 선택 (변경 없음)
-        CreateTodoSection(
-            icon = rememberVectorPainter(image = Icons.Default.Pets),
-            title = "반려동물 선택"
-        ) {
-            PetSelector(
-                allPets = allPets,
-                selectedPets = selectedPets,
-                isDropdownVisible = isPetDropdownVisible,
-                onDropdownClicked = onPetDropdownClicked,
-                onDropdownDismissed = onPetDropdownDismissed,
-                onPetSelected = onPetSelected,
-                onPetTagRemoved = onPetTagRemoved
-            )
-        }
-
-        Spacer(modifier = Modifier.height(32.dp))
-    }
-}
-
-// --- 5. 섹션 템플릿 (변경 없음) ---
+// (기존) 섹션 래퍼 - 변경 없음
 @Composable
 private fun CreateTodoSection(
     icon: Painter,
@@ -335,19 +289,130 @@ private fun CreateTodoSection(
     }
 }
 
-// --- 6. '누가' 섹션 (변경 없음) ---
+
+// (기존) 본문 (스크롤 영역) - 변경 없음
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CreateTodoContent(
+    modifier: Modifier = Modifier,
+    isEditMode: Boolean,
+    shakeOffset: Float,
+    familyMembers: List<FamilyMember>,
+    selectedMember: FamilyMember?,
+    taskTitle: String,
+    selectedDate: Long,
+    isDatePickerVisible: Boolean,
+    allPets: List<Pet>,
+    selectedPets: List<Pet>,
+    isPetDropdownVisible: Boolean,
+    onMemberSelected: (FamilyMember) -> Unit,
+    onTaskTitleChanged: (String) -> Unit,
+    onDatePickerClicked: () -> Unit,
+    onDateSelected: (Long?) -> Unit,
+    onDatePickerDismissed: () -> Unit,
+    onPetDropdownClicked: () -> Unit,
+    onPetDropdownDismissed: () -> Unit,
+    onPetSelected: (Pet) -> Unit,
+    onPetTagRemoved: (Pet) -> Unit
+) {
+    // (기존) 날짜 선택 다이얼로그 (변경 없음)
+    if (isDatePickerVisible) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate
+        )
+        DatePickerDialog(
+            onDismissRequest = onDatePickerDismissed,
+            confirmButton = {
+                TextButton(onClick = {
+                    onDateSelected(datePickerState.selectedDateMillis)
+                }) { Text("확인") }
+            },
+            dismissButton = {
+                TextButton(onClick = onDatePickerDismissed) { Text("취소") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(
+                start = 24.dp,
+                end = 24.dp,
+                bottom = 104.dp
+            ),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Spacer(modifier = Modifier.height(10.dp))
+
+        CreateTodoSection(
+            icon = rememberVectorPainter(image = Icons.Default.Person),
+            title = "누가"
+        ) {
+            AssigneeSelector(
+                members = familyMembers,
+                selectedMember = selectedMember,
+                onMemberSelected = onMemberSelected,
+                enabled = !isEditMode // ★ 수정 모드 시 비활성화 (유지)
+            )
+        }
+
+        CreateTodoSection(
+            icon = painterResource(id = R.drawable.date_under),
+            title = "언제"
+        ) {
+            DatePickerField(
+                selectedDateMillis = selectedDate,
+                onClick = onDatePickerClicked
+            )
+        }
+
+        CreateTodoSection(
+            icon = rememberVectorPainter(image = Icons.Default.CheckBox),
+            title = "해야 할 일"
+        ) {
+            TaskTextField(
+                text = taskTitle,
+                onValueChange = onTaskTitleChanged,
+                shakeOffset = shakeOffset
+            )
+        }
+
+        CreateTodoSection(
+            icon = rememberVectorPainter(image = Icons.Default.Pets),
+            title = "반려동물 선택"
+        ) {
+            PetSelector(
+                allPets = allPets,
+                selectedPets = selectedPets,
+                isDropdownVisible = isPetDropdownVisible,
+                onDropdownClicked = onPetDropdownClicked,
+                onDropdownDismissed = onPetDropdownDismissed,
+                onPetSelected = onPetSelected,
+                onPetTagRemoved = onPetTagRemoved,
+                enabled = true // ★★★ (수정) 수정 모드에서도 펫은 추가/삭제 가능
+            )
+        }
+    }
+}
+
+// (기존) '누가' 섹션 - 변경 없음
 @Composable
 private fun AssigneeSelector(
     members: List<FamilyMember>,
     selectedMember: FamilyMember?,
-    onMemberSelected: (FamilyMember) -> Unit
+    onMemberSelected: (FamilyMember) -> Unit,
+    enabled: Boolean
 ) {
     Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
         members.forEach { member ->
             AssigneeItem(
                 member = member,
                 isSelected = member.userId == selectedMember?.userId,
-                onClick = { onMemberSelected(member) }
+                onClick = { if (enabled) onMemberSelected(member) },
+                enabled = enabled
             )
         }
     }
@@ -357,11 +422,13 @@ private fun AssigneeSelector(
 private fun AssigneeItem(
     member: FamilyMember,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    enabled: Boolean
 ) {
+    val alpha = if (enabled) 1f else 0.4f
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clickable(onClick = onClick)
+        modifier = Modifier.clickable(enabled = enabled, onClick = onClick)
     ) {
         Box(
             contentAlignment = Alignment.Center,
@@ -370,16 +437,15 @@ private fun AssigneeItem(
                 .clip(CircleShape)
                 .border(
                     width = if (isSelected) 2.dp else 1.dp,
-                    color = if (isSelected) Color.Black else Color.LightGray,
+                    color = (if (isSelected) Color.Black else Color.LightGray).copy(alpha = alpha),
                     shape = CircleShape
                 )
         ) {
-            // TODO: Coil 라이브러리 (AsyncImage)
             Icon(
                 imageVector = Icons.Default.AccountCircle,
                 contentDescription = null,
                 modifier = Modifier.size(40.dp),
-                tint = Color.LightGray
+                tint = Color.LightGray.copy(alpha = alpha)
             )
         }
         Text(
@@ -387,19 +453,18 @@ private fun AssigneeItem(
             fontSize = 14.sp,
             modifier = Modifier.padding(top = 8.dp),
             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-            color = if (isSelected) Color.Black else Color.Gray
+            color = (if (isSelected) Color.Black else Color.Gray).copy(alpha = alpha)
         )
     }
 }
 
-// --- 7. '언제' 섹션 (Long -> String 변환 로직 추가) ---
+// (기존) '언제' 섹션 - 변경 없음
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DatePickerField(
-    selectedDateMillis: Long, // (변경) ViewModel의 Long State
+    selectedDateMillis: Long,
     onClick: () -> Unit
 ) {
-    // (추가) Long 값을 "yyyy년 MM월 dd일" 형식으로 변환
     val formatter = SimpleDateFormat("yyyy년 MM월 dd일", Locale.getDefault())
     val dateString = formatter.format(Date(selectedDateMillis))
 
@@ -407,7 +472,7 @@ private fun DatePickerField(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(17.dp),
         color = MaterialTheme.colorScheme.surfaceVariant,
-        onClick = onClick // 클릭 시 DatePicker 띄우기
+        onClick = onClick
     ) {
         Row(
             modifier = Modifier.padding(16.dp),
@@ -417,7 +482,7 @@ private fun DatePickerField(
             Column {
                 Text("date", fontSize = 10.sp, color = Color.Gray)
                 Text(
-                    text = dateString, // (변경) 포맷된 날짜 문자열 표시
+                    text = dateString,
                     fontWeight = FontWeight.Medium,
                     fontSize = 13.sp
                 )
@@ -427,18 +492,23 @@ private fun DatePickerField(
 }
 
 
-// --- 8. '해야 할 일' 섹션 (변경 없음) ---
+// (기존) '해야 할 일' 섹션 - 변경 없음
 @Composable
 private fun TaskTextField(
     text: String,
-    onValueChange: (String) -> Unit
+    onValueChange: (String) -> Unit,
+    shakeOffset: Float
 ) {
     val maxChars = 20
     Column {
         OutlinedTextField(
             value = text,
             onValueChange = onValueChange,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .graphicsLayer {
+                    translationX = shakeOffset
+                },
             shape = RoundedCornerShape(17.dp),
             placeholder = { Text("해야 할 일을 입력해 주세요", fontWeight = FontWeight.Medium, fontSize = 13.sp) },
             maxLines = 3,
@@ -455,8 +525,8 @@ private fun TaskTextField(
     }
 }
 
-// --- 9. '반려동물 선택' 섹션 (변경 없음) ---
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+// ★★★ 3. (수정) '반려동물 선택' 섹션 (수정 모드 UI 수정) ★★★
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun PetSelector(
     allPets: List<Pet>,
@@ -465,47 +535,72 @@ private fun PetSelector(
     onDropdownClicked: () -> Unit,
     onDropdownDismissed: () -> Unit,
     onPetSelected: (Pet) -> Unit,
-    onPetTagRemoved: (Pet) -> Unit
+    onPetTagRemoved: (Pet) -> Unit,
+    enabled: Boolean // (★ enabled는 이제 '드롭다운 활성화' 여부)
 ) {
+    // (수정) 수정 모드일 때는 alpha를 적용하지 않음
+    val alpha = if (enabled) 1f else 0.4f
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        // --- 1. 드롭다운 버튼 ---
         Box {
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(17.dp),
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                onClick = onDropdownClicked // 클릭 시 드롭다운 열기
+                color = MaterialTheme.colorScheme.surfaceVariant, // (수정) 항상 불투명
+                onClick = { if (enabled) onDropdownClicked() } // (수정) 생성 모드일 때만 클릭 가능
             ) {
                 Row(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Image(
-                        imageVector = Icons.Default.AccountCircle, // TODO: 펫 이미지
-                        contentDescription = "펫 프로필",
-                        modifier = Modifier
-                            .size(32.dp)
-                            .clip(CircleShape)
-                    )
+                    if (selectedPets.isEmpty()) {
+                        Image(
+                            imageVector = Icons.Default.AccountCircle,
+                            contentDescription = "펫 프로필",
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .graphicsLayer { this.alpha = alpha }
+                        )
+                    } else {
+                        OverlappingPetIcons(
+                            petNames = selectedPets.map { it.name },
+                            color = Color.Black, // (수정) 항상 불투명
+                            modifier = Modifier.height(32.dp)
+                        )
+                    }
+
                     Spacer(modifier = Modifier.width(8.dp))
+
+                    // ★ (수정) 텍스트가 펫 이름 또는 플레이스홀더를 표시하도록
                     Text(
-                        text = "반려동물을 선택해 주세요",
+                        text = if (selectedPets.isEmpty()) {
+                            "반려동물을 선택해 주세요"
+                        } else {
+                            // (수정) 수정 모드일 때도 펫 이름이 보이도록
+                            selectedPets.joinToString { it.name }
+                        },
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Medium,
-                        color = if (selectedPets.isEmpty()) Color.Gray else MaterialTheme.colorScheme.onSurface
+                        // ★ (수정) 펫이 있으면 활성화된 색상, 비활성화(enabled=false) 시 반투명
+                        color = (if (selectedPets.isEmpty()) Color.Gray else MaterialTheme.colorScheme.onSurface)
+                            .copy(alpha = if (enabled) 1f else 0.4f)
                     )
+
                     Spacer(modifier = Modifier.weight(1f))
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowDown,
-                        contentDescription = "열기",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+
+                    // ★ (수정) 수정 모드(enabled=false)일 때 화살표 숨김
+                    if (enabled) {
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = "열기",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
-
-            // --- 2. 드롭다운 메뉴 ---
             DropdownMenu(
-                expanded = isDropdownVisible,
+                expanded = isDropdownVisible && enabled,
                 onDismissRequest = onDropdownDismissed,
                 modifier = Modifier.fillMaxWidth(0.8f)
             ) {
@@ -518,30 +613,34 @@ private fun PetSelector(
             }
         }
 
-        // --- 3. 펫 태그 (FlowRow) ---
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            selectedPets.forEach { pet ->
-                PetTagChip(
-                    pet = pet,
-                    onRemoveClick = { onPetTagRemoved(pet) }
-                )
+        // ★ (수정) 수정 모드일 때도 태그가 보이도록 (단, 삭제는 안 됨)
+        if (selectedPets.isNotEmpty()) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                selectedPets.forEach { pet ->
+                    PetTagChip(
+                        pet = pet,
+                        onRemoveClick = { onPetTagRemoved(pet) },
+                        enabled = enabled // ★ '생성' 모드일 때만 삭제 가능
+                    )
+                }
             }
         }
     }
 }
 
-// --- (추가) 펫 태그 칩 (변경 없음) ---
+// (기존) 펫 태그 칩 - 변경 없음
 @Composable
 private fun PetTagChip(
     pet: Pet,
-    onRemoveClick: () -> Unit
+    onRemoveClick: () -> Unit,
+    enabled: Boolean
 ) {
     Surface(
         shape = RoundedCornerShape(8.dp),
-        color = Color.Gray // (임시 색상)
+        color = Color.Gray.copy(alpha = if (enabled) 1f else 0.4f)
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
@@ -549,19 +648,93 @@ private fun PetTagChip(
         ) {
             Text(pet.name, fontSize = 12.sp)
             Spacer(modifier = Modifier.width(4.dp))
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = "${pet.name} 삭제",
-                modifier = Modifier
-                    .size(16.dp)
-                    .clickable(onClick = onRemoveClick)
-            )
+
+            if (enabled) { // ★ 생성 모드일 때만 X 아이콘 표시
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "${pet.name} 삭제",
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clickable(onClick = onRemoveClick)
+                )
+            }
         }
     }
 }
 
+// (기존) 겹치는 펫 아이콘 - 3개 + N개
+@Composable
+private fun OverlappingPetIcons(
+    petNames: List<String>,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    if (petNames.isEmpty()) {
+        Spacer(modifier = modifier.width(32.dp).height(32.dp))
+        return
+    }
 
-// --- 10. 미리보기 (변경 없음) ---
+    val displayNames = petNames.take(3)
+    val remaining = (petNames.size - displayNames.size).coerceAtLeast(0)
+
+    val width = (32 + (displayNames.size - 1) * 20 + (if (remaining > 0) 24 else 0)).dp
+    val overlap = 20.dp
+
+    Box(
+        modifier = modifier
+            .width(width)
+            .height(32.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        displayNames.reversed().forEachIndexed { index, name ->
+            PetIconCircle(
+                petName = name,
+                color = color.copy(alpha = 1f - (index * 0.2f)),
+                modifier = Modifier
+                    .padding(start = ((displayNames.size - 1) - index) * overlap)
+                    .size(32.dp)
+            )
+        }
+
+        if (remaining > 0) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(Color.Gray.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "+$remaining",
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = color
+                )
+            }
+        }
+    }
+}
+
+// (기존) 펫 아이콘 헬퍼 - private
+@Composable
+private fun PetIconCircle(petName: String, color: Color, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(Color.Gray.copy(alpha = 0.1f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Pets,
+            contentDescription = petName,
+            tint = color,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
+
+// (기존) 미리보기 - 변경 없음
 @Preview(showBackground = true)
 @Composable
 fun CreateTodoScreenPreview() {

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
@@ -250,8 +250,8 @@ private fun CreateTodoBottomButton(
                 .fillMaxWidth()
                 .height(56.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Black,
-                contentColor = Color.White
+                containerColor = Color(0xFFFFC848),
+                contentColor = Color.Black
             ),
             shape = RoundedCornerShape(12.dp)
         ) {

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
@@ -355,7 +355,7 @@ private fun CreateTodoContent(
                 members = familyMembers,
                 selectedMember = selectedMember,
                 onMemberSelected = onMemberSelected,
-                enabled = !isEditMode // ★ 수정 모드 시 비활성화 (유지)
+                enabled = true
             )
         }
 

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoScreen.kt
@@ -140,8 +140,7 @@ fun CreateTodoScreen(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             CreateTodoTopBar(
-                // ★★★ (수정) "할 일 수정하기"
-                title = if (isEditMode) "할 일 수정하기" else "투두 생성하기",
+                title = if (isEditMode) "투두 수정하기" else "투두 생성하기",
                 onCloseClick = { navController.popBackStack() }
             )
         },
@@ -196,7 +195,6 @@ fun CreateTodoScreen(
     }
 }
 
-// ★★★ 2. (수정) 상단 바 (X 버튼 테두리 제거) ★★★
 @Composable
 private fun CreateTodoTopBar(title: String, onCloseClick: () -> Unit) {
     Box(
@@ -214,7 +212,7 @@ private fun CreateTodoTopBar(title: String, onCloseClick: () -> Unit) {
         )
         IconButton(
             onClick = onCloseClick,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
                 .size(39.dp)
                 .align(Alignment.CenterEnd)
             // ★ (삭제) .border(...)
@@ -392,7 +390,7 @@ private fun CreateTodoContent(
                 onDropdownDismissed = onPetDropdownDismissed,
                 onPetSelected = onPetSelected,
                 onPetTagRemoved = onPetTagRemoved,
-                enabled = true // ★★★ (수정) 수정 모드에서도 펫은 추가/삭제 가능
+                enabled = true
             )
         }
     }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
@@ -7,7 +7,6 @@ import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.data.model.Pet
 import com.example.howsu.data.model.Task
 import com.example.howsu.data.model.TodoGroup
-import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.toObject
 import com.google.firebase.ktx.Firebase
@@ -26,29 +25,35 @@ class CreateTodoViewModel : ViewModel() {
 
     private val db = Firebase.firestore
     private var currentTodoDocumentId: String? = null
-    private var currentTaskId: String? = null // ★ (신규) 수정할 태스크의 ID
+    private var currentTaskId: String? = null
     private val _isEditMode = MutableStateFlow(false)
     val isEditMode: StateFlow<Boolean> = _isEditMode.asStateFlow()
 
-    // --- (기존 State - 변경 없음) ---
+    // State Flows
     private val _familyMembers = MutableStateFlow<List<FamilyMember>>(emptyList())
     val familyMembers: StateFlow<List<FamilyMember>> = _familyMembers.asStateFlow()
+
     private val _selectedMember = MutableStateFlow<FamilyMember?>(null)
     val selectedMember: StateFlow<FamilyMember?> = _selectedMember.asStateFlow()
+
     private val _taskTitle = MutableStateFlow("")
     val taskTitle: StateFlow<String> = _taskTitle.asStateFlow()
+
     private val _selectedDate = MutableStateFlow(System.currentTimeMillis())
     val selectedDate: StateFlow<Long> = _selectedDate.asStateFlow()
+
     private val _isDatePickerVisible = MutableStateFlow(false)
     val isDatePickerVisible: StateFlow<Boolean> = _isDatePickerVisible.asStateFlow()
+
     private val _allPets = MutableStateFlow<List<Pet>>(emptyList())
     val allPets: StateFlow<List<Pet>> = _allPets.asStateFlow()
+
     private val _selectedPets = MutableStateFlow<List<Pet>>(emptyList())
     val selectedPets: StateFlow<List<Pet>> = _selectedPets.asStateFlow()
+
     private val _isPetDropdownVisible = MutableStateFlow(false)
     val isPetDropdownVisible: StateFlow<Boolean> = _isPetDropdownVisible.asStateFlow()
 
-    // (기존) initialize
     fun initialize(documentId: String?) {
         viewModelScope.launch {
             loadInitialData()
@@ -57,13 +62,12 @@ class CreateTodoViewModel : ViewModel() {
                 _isEditMode.value = true
                 loadTodoForEdit(documentId)
             } else {
-                // (수정) 생성 모드일 때 변수 초기화
                 currentTodoDocumentId = null
                 currentTaskId = null
                 _isEditMode.value = false
-                _taskTitle.value = "" // (추가)
-                _selectedPets.value = emptyList() // (추가)
-                _selectedDate.value = System.currentTimeMillis() // (추가)
+                _taskTitle.value = ""
+                _selectedPets.value = emptyList()
+                _selectedDate.value = System.currentTimeMillis()
                 if (_familyMembers.value.isNotEmpty()) {
                     _selectedMember.value = _familyMembers.value.first()
                 }
@@ -71,15 +75,37 @@ class CreateTodoViewModel : ViewModel() {
         }
     }
 
-    // (기존) loadInitialData
     private suspend fun loadInitialData() {
+        // ★ [수정됨] FamilyMember 생성자에 familyId 추가!
+        // (FamilyMember 데이터 클래스가 변경되었기 때문에 여기도 맞춰줘야 함)
         val dummyFamily = listOf(
-            FamilyMember(userId = "user_id_1", relationship = "언니", profileImageUrl = null, nickName = "이구역의짱"),
-            FamilyMember(userId = "user_id_2", relationship = "엄마", profileImageUrl = null, nickName = "엄마2"),
-            FamilyMember(userId = "user_id_3", relationship = "형", profileImageUrl = null, nickName = "형2")
+            FamilyMember(
+                userId = "user_id_1",
+                familyId = "test_family", // 추가됨
+                relationship = "언니",
+                profileImageUrl = null,
+                nickName = "이구역의짱"
+            ),
+            FamilyMember(
+                userId = "user_id_2",
+                familyId = "test_family", // 추가됨
+                relationship = "엄마",
+                profileImageUrl = null,
+                nickName = "엄마2"
+            ),
+            FamilyMember(
+                userId = "user_id_3",
+                familyId = "test_family", // 추가됨
+                relationship = "형",
+                profileImageUrl = null,
+                nickName = "형2"
+            )
         )
         _familyMembers.value = dummyFamily
 
+        // ★ [확인 필요] Pet 데이터 모델도 패키지가 바뀌었는지 확인하세요.
+        // Pet 클래스 생성자에 맞춰서 아래 코드도 수정이 필요할 수 있습니다.
+        // 일단 기존 코드를 유지합니다.
         val dummyPets = listOf(
             Pet(petId = "pet_id_1", name = "자몽", profileImageUrl = null),
             Pet(petId = "pet_id_2", name = "레몬", profileImageUrl = null),
@@ -90,7 +116,6 @@ class CreateTodoViewModel : ViewModel() {
         _allPets.value = dummyPets
     }
 
-    // ★★★ (수정) loadTodoForEdit (태스크 ID 저장) ★★★
     private suspend fun loadTodoForEdit(documentId: String) {
         try {
             val doc = db.collection("todoGroups").document(documentId).get().await()
@@ -99,10 +124,9 @@ class CreateTodoViewModel : ViewModel() {
                 _selectedMember.value = _familyMembers.value.find { it.userId == group.assigneeId }
                 _selectedPets.value = _allPets.value.filter { group.petNames.contains(it.name) }
 
-                // (수정) 그룹의 '첫 번째' 태스크를 수정 대상으로 간주
                 val taskToEdit = group.tasks.firstOrNull()
                 if (taskToEdit != null) {
-                    currentTaskId = taskToEdit.id // ★ (신규) 태스크 ID 저장
+                    currentTaskId = taskToEdit.id
                     _taskTitle.value = taskToEdit.title ?: ""
                 } else {
                     currentTaskId = null
@@ -122,11 +146,11 @@ class CreateTodoViewModel : ViewModel() {
                 }
             }
         } catch (e: Exception) {
-            Log.e("CreateTodoVM", "수정할 할 일($documentId) 로드 실패", e)
+            Log.e("CreateTodoVM", "수정할 할 일 로드 실패", e)
         }
     }
 
-    // --- (기존 UI 이벤트 핸들러 - 변경 없음) ---
+    // --- UI Events ---
     fun onMemberSelected(member: FamilyMember) { _selectedMember.value = member }
     fun onTaskTitleChanged(newTitle: String) { _taskTitle.value = newTitle.take(20) }
     fun onDatePickerClicked() { _isDatePickerVisible.value = true }
@@ -154,54 +178,45 @@ class CreateTodoViewModel : ViewModel() {
         val title = _taskTitle.value
         val dateInMillis = _selectedDate.value
 
-        val currentUser = Firebase.auth.currentUser
-
-        // 유효성 검사 및 familyId 확보
-        val myFamilyId = currentUser?.uid ?: return
-
         if (assignee == null || title.isBlank()) {
             return
         }
+
+        // ★ [중요 수정] 내 UID가 아니라, 선택된 멤버(assignee)가 속한 가족 ID를 사용해야 함
+        // FamilyMember 객체 안에 familyId가 들어있으므로 그걸 사용
+        val myFamilyId = assignee.familyId
+
         val formattedDate = SimpleDateFormat("yyyy. MM. dd", Locale.KOREA).format(Date(dateInMillis))
 
         viewModelScope.launch {
             try {
-                // --- 수정 모드 ---
-                // (주의: 이 로직은 그룹의 '첫 번째' 태스크만 수정하는 한계가 있음)
                 if (_isEditMode.value && currentTodoDocumentId != null && currentTaskId != null) {
-
+                    // --- 수정 모드 ---
                     val docRef = db.collection("todoGroups").document(currentTodoDocumentId!!)
                     val document = docRef.get().await()
                     val group = document.toObject<TodoGroup>() ?: return@launch
 
-                    // 1. (수정) 기존 tasks 리스트에서 'currentTaskId'를 찾아 제목/날짜를 업데이트
                     val updatedTasks = group.tasks.map { task ->
                         if (task.id == currentTaskId) {
-                            task.copy(title = title, date = formattedDate) // ★ 수정
+                            task.copy(title = title, date = formattedDate)
                         } else {
-                            task // ★ 나머지는 그대로 둠
+                            task
                         }
                     }
-
-                    // 2. 펫 이름 목록
                     val mergedPetNames = _selectedPets.value.map { it.name }.distinct()
-
-                    // 3. (수정) 담당자
-                    val finalAssigneeId = assignee.userId
-                    val finalAssigneeName = assignee.relationship
 
                     docRef.update(
                         "tasks", updatedTasks,
                         "petNames", mergedPetNames,
                         "assigneeId", assignee.userId,
-                        "assigneeName", assignee.relationship,
-                        "familyId", myFamilyId // 혹시 모르니 familyId도 업데이트
+                        "assigneeName", assignee.relationship, // 또는 assignee.nickName (기획에 따라)
+                        "familyId", myFamilyId
                     ).await()
 
-                    Log.d("CreateTodoVM", "기존 할 일 그룹 수정 성공")
+                    Log.d("CreateTodoVM", "수정 성공")
 
                 } else {
-                    // --- 생성 모드 (새 그룹 생성) ---
+                    // --- 생성 모드 ---
                     val newTask = Task(
                         id = UUID.randomUUID().toString(),
                         title = title,
@@ -212,19 +227,19 @@ class CreateTodoViewModel : ViewModel() {
                     val newTodoGroup = TodoGroup(
                         familyId = myFamilyId,
                         assigneeId = assignee.userId,
-                        assigneeName = assignee.relationship,
+                        assigneeName = assignee.relationship, // 또는 assignee.nickName
                         assigneeProfileRes = null,
                         tasks = listOf(newTask),
                         petNames = _selectedPets.value.map { it.name }
                     )
 
                     db.collection("todoGroups").add(newTodoGroup).await()
-                    Log.d("CreateTodoVM", "새 할 일 그룹 생성 성공")
+                    Log.d("CreateTodoVM", "생성 성공")
                 }
                 onComplete()
 
             } catch (e: Exception) {
-                Log.e("CreateTodoVM", "할 일 저장/수정 실패", e)
+                Log.e("CreateTodoVM", "저장 실패", e)
             }
         }
     }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
@@ -7,7 +7,6 @@ import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.data.model.Pet
 import com.example.howsu.data.model.Task
 import com.example.howsu.data.model.TodoGroup
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.toObject
 import com.google.firebase.ktx.Firebase
@@ -26,6 +25,7 @@ class CreateTodoViewModel : ViewModel() {
 
     private val db = Firebase.firestore
     private var currentTodoDocumentId: String? = null
+    private var currentTaskId: String? = null // ★ (신규) 수정할 태스크의 ID
     private val _isEditMode = MutableStateFlow(false)
     val isEditMode: StateFlow<Boolean> = _isEditMode.asStateFlow()
 
@@ -56,7 +56,13 @@ class CreateTodoViewModel : ViewModel() {
                 _isEditMode.value = true
                 loadTodoForEdit(documentId)
             } else {
+                // (수정) 생성 모드일 때 변수 초기화
+                currentTodoDocumentId = null
+                currentTaskId = null
                 _isEditMode.value = false
+                _taskTitle.value = "" // (추가)
+                _selectedPets.value = emptyList() // (추가)
+                _selectedDate.value = System.currentTimeMillis() // (추가)
                 if (_familyMembers.value.isNotEmpty()) {
                     _selectedMember.value = _familyMembers.value.first()
                 }
@@ -83,6 +89,7 @@ class CreateTodoViewModel : ViewModel() {
         _allPets.value = dummyPets
     }
 
+    // ★★★ (수정) loadTodoForEdit (태스크 ID 저장) ★★★
     private suspend fun loadTodoForEdit(documentId: String) {
         try {
             val doc = db.collection("todoGroups").document(documentId).get().await()
@@ -91,26 +98,26 @@ class CreateTodoViewModel : ViewModel() {
                 _selectedMember.value = _familyMembers.value.find { it.userId == group.assigneeId }
                 _selectedPets.value = _allPets.value.filter { group.petNames.contains(it.name) }
 
-                // ★★★ (수정) 여기서 제목을 ""로 비우는 대신, 그룹의 '첫 번째' 태스크 제목을 불러옵니다. ★★★
-                val taskToEdit = group.tasks.firstOrNull() // 그룹의 첫 번째 태스크
+                // (수정) 그룹의 '첫 번째' 태스크를 수정 대상으로 간주
+                val taskToEdit = group.tasks.firstOrNull()
                 if (taskToEdit != null) {
+                    currentTaskId = taskToEdit.id // ★ (신규) 태스크 ID 저장
                     _taskTitle.value = taskToEdit.title ?: ""
                 } else {
-                    _taskTitle.value = "" // 태스크가 없는 그룹이면 비워둠
+                    currentTaskId = null
+                    _taskTitle.value = ""
                 }
 
-                // (선택) 날짜도 첫 번째 태스크의 날짜로 맞출 수 있습니다.
                 val firstTaskDate = taskToEdit?.date
                 if (firstTaskDate != null) {
                     try {
-                        // 날짜 형식이 "yyyy. MM. dd"이므로 파싱합니다.
                         val formatter = SimpleDateFormat("yyyy. MM. dd", Locale.KOREA)
                         _selectedDate.value = formatter.parse(firstTaskDate)?.time ?: System.currentTimeMillis()
                     } catch (e: Exception) {
-                        _selectedDate.value = System.currentTimeMillis() // 파싱 실패 시 오늘 날짜
+                        _selectedDate.value = System.currentTimeMillis()
                     }
                 } else {
-                    _selectedDate.value = System.currentTimeMillis() // 태스크가 없으면 오늘 날짜
+                    _selectedDate.value = System.currentTimeMillis()
                 }
             }
         } catch (e: Exception) {
@@ -141,7 +148,7 @@ class CreateTodoViewModel : ViewModel() {
         }
     }
 
-    // ★★★ (대폭 수정) saveTodo (펫 병합 로직 수정) ★★★
+    // ★★★ (대폭 수정) saveTodo (진짜 '수정' 로직 구현) ★★★
     fun saveTodo(onComplete: () -> Unit) {
         val assignee = _selectedMember.value
         val title = _taskTitle.value
@@ -153,41 +160,51 @@ class CreateTodoViewModel : ViewModel() {
 
         val formattedDate = SimpleDateFormat("yyyy. MM. dd", Locale.KOREA).format(Date(dateInMillis))
 
-        val newTask = Task(
-            id = UUID.randomUUID().toString(),
-            title = title,
-            date = formattedDate,
-            isChecked = false
-        )
-
         viewModelScope.launch {
             try {
-                if (_isEditMode.value && currentTodoDocumentId != null) {
-                    // --- 수정 모드 (Task 추가 + Pet 병합) ---
+                // --- 수정 모드 ---
+                // (주의: 이 로직은 그룹의 '첫 번째' 태스크만 수정하는 한계가 있음)
+                if (_isEditMode.value && currentTodoDocumentId != null && currentTaskId != null) {
+
                     val docRef = db.collection("todoGroups").document(currentTodoDocumentId!!)
+                    val document = docRef.get().await()
+                    val group = document.toObject<TodoGroup>() ?: return@launch
 
-                    // 1. Task Map 변환
-                    val taskMap = mapOf(
-                        "id" to newTask.id,
-                        "title" to newTask.title,
-                        "date" to newTask.date,
-                        "isChecked" to newTask.isChecked
-                    )
+                    // 1. (수정) 기존 tasks 리스트에서 'currentTaskId'를 찾아 제목/날짜를 업데이트
+                    val updatedTasks = group.tasks.map { task ->
+                        if (task.id == currentTaskId) {
+                            task.copy(title = title, date = formattedDate) // ★ 수정
+                        } else {
+                            task // ★ 나머지는 그대로 둠
+                        }
+                    }
 
-                    // 2. (수정) 펫 이름 목록 (중복 제거)
-                    // (수정 모드에서는 _selectedPets가 기존+신규 펫을 모두 들고 있음)
+                    // 2. 펫 이름 목록
                     val mergedPetNames = _selectedPets.value.map { it.name }.distinct()
 
-                    // 3. 'tasks'는 추가(arrayUnion), 'petNames'는 덮어쓰기(set)
+                    // 3. (수정) 담당자
+                    val finalAssigneeId = assignee.userId
+                    val finalAssigneeName = assignee.relationship
+
+                    // 4. (수정) 'tasks'와 'petNames' 필드 전체를 덮어쓰기 (arrayUnion 아님)
                     docRef.update(
-                        "tasks", FieldValue.arrayUnion(taskMap),
-                        "petNames", mergedPetNames
+                        "tasks", updatedTasks,
+                        "petNames", mergedPetNames,
+                        "assigneeId", finalAssigneeId,
+                        "assigneeName", finalAssigneeName
                     ).await()
 
-                    Log.d("CreateTodoVM", "기존 할 일 그룹에 Task/Pet 추가 성공")
+                    Log.d("CreateTodoVM", "기존 할 일 그룹 수정 성공")
 
                 } else {
                     // --- 생성 모드 (새 그룹 생성) ---
+                    val newTask = Task(
+                        id = UUID.randomUUID().toString(),
+                        title = title,
+                        date = formattedDate,
+                        isChecked = false
+                    )
+
                     val newTodoGroup = TodoGroup(
                         assigneeId = assignee.userId,
                         assigneeName = assignee.relationship,

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
@@ -1,26 +1,35 @@
 package com.example.howsu.screen.todo
 
-// ★ 1. 날짜 포맷을 위한 임포트 3줄
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.data.model.Pet
+import com.example.howsu.data.model.Task
+import com.example.howsu.data.model.TodoGroup
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.firestore.toObject
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.UUID
 
 class CreateTodoViewModel : ViewModel() {
 
     private val db = Firebase.firestore
+    private var currentTodoDocumentId: String? = null
+    private val _isEditMode = MutableStateFlow(false)
+    val isEditMode: StateFlow<Boolean> = _isEditMode.asStateFlow()
 
-    // --- (모든 State 변수와 init, loadInitialData, 이벤트 핸들러는 동일) ---
+    // --- (기존 State - 변경 없음) ---
     private val _familyMembers = MutableStateFlow<List<FamilyMember>>(emptyList())
     val familyMembers: StateFlow<List<FamilyMember>> = _familyMembers.asStateFlow()
     private val _selectedMember = MutableStateFlow<FamilyMember?>(null)
@@ -38,33 +47,78 @@ class CreateTodoViewModel : ViewModel() {
     private val _isPetDropdownVisible = MutableStateFlow(false)
     val isPetDropdownVisible: StateFlow<Boolean> = _isPetDropdownVisible.asStateFlow()
 
-    init {
-        loadInitialData()
-    }
-
-    private fun loadInitialData() {
+    // (기존) initialize
+    fun initialize(documentId: String?) {
         viewModelScope.launch {
-            // (임시) 더미 데이터로 가족 목록
-            val dummyFamily = listOf(
-                FamilyMember(userId = "user_id_1", relationship = "언니", profileImageUrl = null, nickName = "이구역의짱"),
-                FamilyMember(userId = "user_id_2", relationship = "엄마", profileImageUrl = null, nickName = "엄마2"),
-                FamilyMember(userId = "user_id_3", relationship = "형", profileImageUrl = null, nickName = "형2")
-            )
-            _familyMembers.value = dummyFamily
-            if (dummyFamily.isNotEmpty()) {
-                _selectedMember.value = dummyFamily.first()
+            loadInitialData()
+            if (documentId != null) {
+                currentTodoDocumentId = documentId
+                _isEditMode.value = true
+                loadTodoForEdit(documentId)
+            } else {
+                _isEditMode.value = false
+                if (_familyMembers.value.isNotEmpty()) {
+                    _selectedMember.value = _familyMembers.value.first()
+                }
             }
-            // (임시) 더미 데이터로 반려동물 목록
-            val dummyPets = listOf(
-                Pet(petId = "pet_id_1", name = "자몽", profileImageUrl = null),
-                Pet(petId = "pet_id_2", name = "레몬", profileImageUrl = null),
-                Pet(petId = "pet_id_3", name = "망고", profileImageUrl = null)
-            )
-            _allPets.value = dummyPets
         }
     }
 
-    // --- (UI 이벤트 핸들러들은 동일) ---
+    // (기존) loadInitialData
+    private suspend fun loadInitialData() {
+        val dummyFamily = listOf(
+            FamilyMember(userId = "user_id_1", relationship = "언니", profileImageUrl = null, nickName = "이구역의짱"),
+            FamilyMember(userId = "user_id_2", relationship = "엄마", profileImageUrl = null, nickName = "엄마2"),
+            FamilyMember(userId = "user_id_3", relationship = "형", profileImageUrl = null, nickName = "형2")
+        )
+        _familyMembers.value = dummyFamily
+
+        val dummyPets = listOf(
+            Pet(petId = "pet_id_1", name = "자몽", profileImageUrl = null),
+            Pet(petId = "pet_id_2", name = "레몬", profileImageUrl = null),
+            Pet(petId = "pet_id_3", name = "망고", profileImageUrl = null),
+            Pet(petId = "pet_id_4", name = "수박", profileImageUrl = null),
+            Pet(petId = "pet_id_5", name = "키위", profileImageUrl = null)
+        )
+        _allPets.value = dummyPets
+    }
+
+    private suspend fun loadTodoForEdit(documentId: String) {
+        try {
+            val doc = db.collection("todoGroups").document(documentId).get().await()
+            val group = doc.toObject<TodoGroup>()
+            if (group != null) {
+                _selectedMember.value = _familyMembers.value.find { it.userId == group.assigneeId }
+                _selectedPets.value = _allPets.value.filter { group.petNames.contains(it.name) }
+
+                // ★★★ (수정) 여기서 제목을 ""로 비우는 대신, 그룹의 '첫 번째' 태스크 제목을 불러옵니다. ★★★
+                val taskToEdit = group.tasks.firstOrNull() // 그룹의 첫 번째 태스크
+                if (taskToEdit != null) {
+                    _taskTitle.value = taskToEdit.title ?: ""
+                } else {
+                    _taskTitle.value = "" // 태스크가 없는 그룹이면 비워둠
+                }
+
+                // (선택) 날짜도 첫 번째 태스크의 날짜로 맞출 수 있습니다.
+                val firstTaskDate = taskToEdit?.date
+                if (firstTaskDate != null) {
+                    try {
+                        // 날짜 형식이 "yyyy. MM. dd"이므로 파싱합니다.
+                        val formatter = SimpleDateFormat("yyyy. MM. dd", Locale.KOREA)
+                        _selectedDate.value = formatter.parse(firstTaskDate)?.time ?: System.currentTimeMillis()
+                    } catch (e: Exception) {
+                        _selectedDate.value = System.currentTimeMillis() // 파싱 실패 시 오늘 날짜
+                    }
+                } else {
+                    _selectedDate.value = System.currentTimeMillis() // 태스크가 없으면 오늘 날짜
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("CreateTodoVM", "수정할 할 일($documentId) 로드 실패", e)
+        }
+    }
+
+    // --- (기존 UI 이벤트 핸들러 - 변경 없음) ---
     fun onMemberSelected(member: FamilyMember) { _selectedMember.value = member }
     fun onTaskTitleChanged(newTitle: String) { _taskTitle.value = newTitle.take(20) }
     fun onDatePickerClicked() { _isDatePickerVisible.value = true }
@@ -87,59 +141,69 @@ class CreateTodoViewModel : ViewModel() {
         }
     }
 
-    /**
-     * '투두 생성 완료' 버튼 클릭 (★ 여기가 수정되었습니다 ★)
-     */
-    fun createTodo(onComplete: () -> Unit) {
+    // ★★★ (대폭 수정) saveTodo (펫 병합 로직 수정) ★★★
+    fun saveTodo(onComplete: () -> Unit) {
         val assignee = _selectedMember.value
         val title = _taskTitle.value
         val dateInMillis = _selectedDate.value
-        val pets = _selectedPets.value
 
         if (assignee == null || title.isBlank()) {
             return
         }
 
-        // --- '투두 등록' 로직 ---
-
-        // ★ 2. 날짜 포맷 변경 (Long -> "yyyy. MM. dd")
         val formattedDate = SimpleDateFormat("yyyy. MM. dd", Locale.KOREA).format(Date(dateInMillis))
 
-        // ★ 3. 담당자 이름 포맷 변경 ("언니" -> "언니(이)가")
-        val formattedAssigneeName = when (assignee.relationship) {
-            "언니" -> "언니(이)가"
-            "엄마" -> "엄마(이)가"
-            "형" -> "형(이)가"
-            else -> "${assignee.relationship}(이)가"
+        val newTask = Task(
+            id = UUID.randomUUID().toString(),
+            title = title,
+            date = formattedDate,
+            isChecked = false
+        )
+
+        viewModelScope.launch {
+            try {
+                if (_isEditMode.value && currentTodoDocumentId != null) {
+                    // --- 수정 모드 (Task 추가 + Pet 병합) ---
+                    val docRef = db.collection("todoGroups").document(currentTodoDocumentId!!)
+
+                    // 1. Task Map 변환
+                    val taskMap = mapOf(
+                        "id" to newTask.id,
+                        "title" to newTask.title,
+                        "date" to newTask.date,
+                        "isChecked" to newTask.isChecked
+                    )
+
+                    // 2. (수정) 펫 이름 목록 (중복 제거)
+                    // (수정 모드에서는 _selectedPets가 기존+신규 펫을 모두 들고 있음)
+                    val mergedPetNames = _selectedPets.value.map { it.name }.distinct()
+
+                    // 3. 'tasks'는 추가(arrayUnion), 'petNames'는 덮어쓰기(set)
+                    docRef.update(
+                        "tasks", FieldValue.arrayUnion(taskMap),
+                        "petNames", mergedPetNames
+                    ).await()
+
+                    Log.d("CreateTodoVM", "기존 할 일 그룹에 Task/Pet 추가 성공")
+
+                } else {
+                    // --- 생성 모드 (새 그룹 생성) ---
+                    val newTodoGroup = TodoGroup(
+                        assigneeId = assignee.userId,
+                        assigneeName = assignee.relationship,
+                        assigneeProfileRes = null,
+                        tasks = listOf(newTask),
+                        petNames = _selectedPets.value.map { it.name }
+                    )
+
+                    db.collection("todoGroups").add(newTodoGroup).await()
+                    Log.d("CreateTodoVM", "새 할 일 그룹 생성 성공")
+                }
+                onComplete()
+
+            } catch (e: Exception) {
+                Log.e("CreateTodoVM", "할 일 저장/수정 실패", e)
+            }
         }
-
-        // ★ 4. Task 맵 생성 (Task 모델에 맞게)
-        val newTasks = listOf(
-            mapOf(
-                "id" to (0..10000).random(), // 임시 ID
-                "title" to title,
-                "date" to formattedDate, // ★ 포맷된 날짜 사용
-                "isChecked" to false
-            )
-        )
-
-        // ★ 5. TodoGroup 맵 생성 (TodoGroup 모델에 맞게)
-        val newTodoGroup = mapOf(
-            "id" to (0..10000).random(), // 임시 ID
-            "assigneeName" to formattedAssigneeName, // ★ 포맷된 이름 사용
-            "assigneeProfileRes" to null,
-            "tasks" to newTasks
-        )
-
-        // ★ 6. Firestore에 저장
-        db.collection("todoGroups")
-            .add(newTodoGroup)
-            .addOnSuccessListener {
-                println("--- 할 일 생성 성공 ---")
-                onComplete() // ★ 성공 시에만 화면 이동
-            }
-            .addOnFailureListener { e ->
-                println("--- 할 일 생성 실패 ---: $e")
-            }
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/CreateTodoViewModel.kt
@@ -7,6 +7,7 @@ import com.example.howsu.data.model.FamilyMember
 import com.example.howsu.data.model.Pet
 import com.example.howsu.data.model.Task
 import com.example.howsu.data.model.TodoGroup
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.toObject
 import com.google.firebase.ktx.Firebase
@@ -148,16 +149,19 @@ class CreateTodoViewModel : ViewModel() {
         }
     }
 
-    // ★★★ (대폭 수정) saveTodo (진짜 '수정' 로직 구현) ★★★
     fun saveTodo(onComplete: () -> Unit) {
         val assignee = _selectedMember.value
         val title = _taskTitle.value
         val dateInMillis = _selectedDate.value
 
+        val currentUser = Firebase.auth.currentUser
+
+        // 유효성 검사 및 familyId 확보
+        val myFamilyId = currentUser?.uid ?: return
+
         if (assignee == null || title.isBlank()) {
             return
         }
-
         val formattedDate = SimpleDateFormat("yyyy. MM. dd", Locale.KOREA).format(Date(dateInMillis))
 
         viewModelScope.launch {
@@ -186,12 +190,12 @@ class CreateTodoViewModel : ViewModel() {
                     val finalAssigneeId = assignee.userId
                     val finalAssigneeName = assignee.relationship
 
-                    // 4. (수정) 'tasks'와 'petNames' 필드 전체를 덮어쓰기 (arrayUnion 아님)
                     docRef.update(
                         "tasks", updatedTasks,
                         "petNames", mergedPetNames,
-                        "assigneeId", finalAssigneeId,
-                        "assigneeName", finalAssigneeName
+                        "assigneeId", assignee.userId,
+                        "assigneeName", assignee.relationship,
+                        "familyId", myFamilyId // 혹시 모르니 familyId도 업데이트
                     ).await()
 
                     Log.d("CreateTodoVM", "기존 할 일 그룹 수정 성공")
@@ -206,6 +210,7 @@ class CreateTodoViewModel : ViewModel() {
                     )
 
                     val newTodoGroup = TodoGroup(
+                        familyId = myFamilyId,
                         assigneeId = assignee.userId,
                         assigneeName = assignee.relationship,
                         assigneeProfileRes = null,

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
@@ -1,9 +1,7 @@
 package com.example.howsu.screen.todo
 
-// import androidx.compose.material.icons.filled.ArrowBackIosNew // ★ 2. (삭제)
-// import androidx.compose.material.icons.filled.ArrowForwardIos // ★ 3. (삭제)
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border // ★ (신규) border 임포트
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -44,6 +42,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,25 +59,21 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.times
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.howsu.R
 import com.example.howsu.common.MyBottomNavigationBar
 import com.example.howsu.common.MyFloatingActionButton
 import com.example.howsu.data.model.Task
 import com.example.howsu.data.model.TodoGroup
-import com.example.howsu.ui.theme.HowsuTheme
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-
+import kotlin.math.abs
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,7 +83,12 @@ fun TodoScreen(
 ) {
     val todoGroups by viewModel.todoGroups.collectAsState(initial = emptyList())
     val selectedDate by viewModel.selectedDate.collectAsState()
+    val currentWeekStart by viewModel.currentWeekStart.collectAsState()
     var showDatePicker by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.resetToToday()
+    }
 
     if (showDatePicker) {
         val datePickerState = rememberDatePickerState(
@@ -129,9 +129,7 @@ fun TodoScreen(
                 )
             )
         },
-        bottomBar = {
-            MyBottomNavigationBar(navController = navController)
-        },
+        bottomBar = { MyBottomNavigationBar(navController = navController) },
         floatingActionButton = {
             MyFloatingActionButton(
                 onTodoClick = { navController.navigate("create_todo") },
@@ -145,12 +143,13 @@ fun TodoScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
         ) {
-            val today = LocalDate.now() // ★ (신규) 오늘 날짜 가져오기
+            val today = LocalDate.now()
 
             CalendarWeekRow(
                 selectedDate = selectedDate,
-                today = today, // ★ (신규) 오늘 날짜 전달
-                onDateChange = viewModel::onDateChange,
+                currentWeekStart = currentWeekStart,
+                today = today,
+                onWeekSwipe = viewModel::onWeekSwipe,
                 onWeekDaySelected = viewModel::onWeekDaySelected
             )
 
@@ -173,17 +172,17 @@ fun TodoScreen(
     }
 }
 
-// ★★★ 5. (수정) 주간 캘린더 (스와이프 + 동그라미 + 테두리) ★★★
+// ★★★ 핵심 수정: 터치와 스와이프 완벽 분리 및 UI 수정 ★★★
 @Composable
 fun CalendarWeekRow(
     selectedDate: LocalDate,
-    today: LocalDate, // ★ (신규) '오늘' 날짜 받기
-    onDateChange: (days: Long) -> Unit, // (Boolean -> Long)
+    currentWeekStart: LocalDate,
+    today: LocalDate,
+    onWeekSwipe: (days: Long) -> Unit,
     onWeekDaySelected: (LocalDate) -> Unit
 ) {
-    val startOfWeek = selectedDate.with(DayOfWeek.SUNDAY)
+    val startOfWeek = currentWeekStart
     val weekDates = List(7) { i -> startOfWeek.plusDays(i.toLong()) }
-
     val dayFormatter = DateTimeFormatter.ofPattern("d", Locale.KOREAN)
     val dayOfWeekFormatter = DateTimeFormatter.ofPattern("E", Locale.KOREAN)
 
@@ -191,89 +190,79 @@ fun CalendarWeekRow(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp, horizontal = 16.dp)
-            // ★ (신규) 스와이프 제스처 추가
             .pointerInput(Unit) {
-                var totalDragAmount = 0f // 1. 드래그 거리를 저장할 변수
-
+                // ★★★ 터치 분리 로직 ★★★
+                var totalDrag = 0f
                 detectHorizontalDragGestures(
-                    // 2. 드래그하는 동안 x축 이동 거리를 totalDragAmount에 누적
-                    onHorizontalDrag = { change, dragAmount ->
-                        change.consume()
-                        totalDragAmount += dragAmount
-                    },
-                    // 3. 드래그가 끝나면(손가락을 떼면)
                     onDragEnd = {
-                        if (totalDragAmount > 50) { // ★ 오른쪽으로 50px 이상
-                            onDateChange(-7) // 이전 주 (7일 빼기)
-                        } else if (totalDragAmount < -50) { // ★ 왼쪽으로 50px 이상
-                            onDateChange(7) // 다음 주 (7일 더하기)
-                        }
-                        totalDragAmount = 0f // 4. 거리 리셋
+                        // 드래그가 끝났을 때, 이동 거리가 충분히 길어야만(100px) 주 이동 실행
+                        if (totalDrag < -100f) onWeekSwipe(7)
+                        else if (totalDrag > 100f) onWeekSwipe(-7)
+                        totalDrag = 0f
                     },
-                    // 5. 드래그가 취소돼도 리셋
-                    onDragCancel = {
-                        totalDragAmount = 0f
+                    onHorizontalDrag = { change, dragAmount ->
+                        totalDrag += dragAmount
+
+                        // ★ 중요: 움직임이 30px 이상일 때만 이벤트를 '소비(consume)'함
+                        // 즉, 살짝 움직이는 건(30px 미만) 클릭으로 통과되고,
+                        // 크게 움직여야만 스와이프로 인식됨.
+                        if (abs(totalDrag) > 30f) {
+                            change.consume()
+                        }
                     }
                 )
             },
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceAround // ★ (수정) SpaceEvenly -> SpaceAround
+        horizontalArrangement = Arrangement.SpaceAround
     ) {
-        // ★ (삭제) < 버튼
-
         weekDates.forEach { date ->
             val isSelected = date == selectedDate
-            val isToday = date == today // ★ (신규) 오늘인지 확인
+            val isToday = date == today
+
+            // ★ UI 로직:
+            // 1. 오늘 날짜(isToday) = 검은색 채워진 동그라미 + 흰색 글씨
+            // 2. 선택된 날짜(isSelected)이면서 오늘이 아님 = 검은색 테두리 + 검은색 글씨
+            // 3. 그 외 = 투명 + 검은색 글씨
+
+            val backgroundColor = if (isToday) Color.Black else Color.Transparent
+            val borderColor = if (isSelected && !isToday) Color.Black else Color.Transparent
+            val textColor = if (isToday) Color.White else Color.Black
 
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
-                    .weight(1f) // ★ 동일 너비
+                    .weight(1f)
                     .clip(RoundedCornerShape(12.dp))
-                    .clickable { onWeekDaySelected(date) }
+                    .clickable { onWeekDaySelected(date) } // 클릭은 여기서 처리
                     .padding(vertical = 8.dp, horizontal = 4.dp)
             ) {
-                // "월"
                 Text(
                     text = date.format(dayOfWeekFormatter),
                     fontSize = 12.sp,
-                    color = Color.Gray // ★ 선택 여부와 관계없이 회색
+                    color = Color.Gray
                 )
                 Spacer(modifier = Modifier.height(4.dp))
 
-                // "17" (★ 수정 - 동그라미/테두리)
                 Box(
                     modifier = Modifier
-                        .size(32.dp) // 동그라미 크기
+                        .size(32.dp)
                         .clip(CircleShape)
-                        .background(
-                            if (isSelected) Color.Black else Color.Transparent // ★ 선택 시 검은 배경
-                        )
-                        .then(
-                            // ★ (신규) 오늘이고, 선택되지 않았을 때만 테두리
-                            if (isToday && !isSelected) {
-                                Modifier.border(1.5.dp, Color.Black, CircleShape)
-                            } else {
-                                Modifier
-                            }
-                        ),
+                        .background(backgroundColor)
+                        .border(1.5.dp, borderColor, CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = date.format(dayFormatter),
                         fontSize = 14.sp,
                         fontWeight = FontWeight.SemiBold,
-                        color = if (isSelected) Color.White else Color.Black // ★ 선택 시 흰색
+                        color = textColor
                     )
                 }
             }
         }
-
-        // ★ (삭제) > 버튼
     }
 }
 
-// (기존) 날짜 헤더 (변경 없음)
 @Composable
 fun DailyHeader(selectedDate: LocalDate) {
     val formatter = DateTimeFormatter.ofPattern("M월 d일 E요일", Locale.KOREAN)
@@ -293,8 +282,6 @@ fun DailyHeader(selectedDate: LocalDate) {
     }
 }
 
-
-// (기존) TodoGroupCard (변경 없음)
 @Composable
 fun TodoGroupCard(
     group: TodoGroup,
@@ -306,13 +293,9 @@ fun TodoGroupCard(
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
-        )
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
-        Column(
-            modifier = Modifier.padding(vertical = 10.dp)
-        ) {
+        Column(modifier = Modifier.padding(vertical = 10.dp)) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -341,11 +324,7 @@ fun TodoGroupCard(
 
                 Box {
                     IconButton(onClick = { isMenuExpanded = true }) {
-                        Icon(
-                            Icons.Default.MoreVert,
-                            contentDescription = "더보기",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        Icon(Icons.Default.MoreVert, contentDescription = "더보기", tint = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                     DropdownMenu(
                         expanded = isMenuExpanded,
@@ -367,7 +346,7 @@ fun TodoGroupCard(
                         )
                     }
                 }
-            } // --- Row 끝 ---
+            }
 
             Spacer(modifier = Modifier.height(1.dp))
 
@@ -388,7 +367,6 @@ fun TodoGroupCard(
     }
 }
 
-// ★★★ 6. (수정) TaskItemRow (Row 전체 클릭) ★★★
 @Composable
 fun TaskItemRow(
     task: Task,
@@ -397,8 +375,8 @@ fun TaskItemRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(4.dp))
-            .clickable { onCheckedChange(!task.isChecked) }, // ★ (신규) Row 전체 클릭
+            .height(48.dp)
+            .padding(horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(
@@ -409,108 +387,71 @@ fun TaskItemRow(
                 uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant
             )
         )
+
         Text(
             text = task.title ?: "",
             modifier = Modifier
-                .padding(start = 0.5.dp)
-                .weight(0.5f),
+                .weight(1f)
+                .padding(start = 8.dp),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.Medium,
-            fontSize = 12.sp,
+            fontSize = 15.sp,
             maxLines = 1,
             textDecoration = if (task.isChecked) TextDecoration.LineThrough else TextDecoration.None
         )
-        Spacer(modifier = Modifier.width(10.dp))
+
         Text(
             text = task.date ?: "",
             fontWeight = FontWeight.Medium,
             fontSize = 11.sp,
-            color = Color.Black
+            color = Color.Gray,
+            modifier = Modifier.padding(start = 8.dp)
         )
     }
 }
 
 
-@Preview(showBackground = true)
-@Composable
-fun TodoScreenPreview() {
-    HowsuTheme {
-        val navController = rememberNavController()
-        TodoScreen(navController = navController)
-    }
-}
-
-// ★★★ 7. (수정) 펫 아이콘 (3개 + N개)
+// --- (기존 펫 아이콘 관련 코드 유지) ---
 @Composable
 private fun OverlappingPetIcons(
     petNames: List<String>,
     color: Color,
     modifier: Modifier = Modifier
 ) {
-    if (petNames.isEmpty()) {
-        return
-    }
-
-    val displayNames = petNames.take(3) // ★ 최대 3개만 표시
+    if (petNames.isEmpty()) return
+    val displayNames = petNames.take(3)
     val remaining = (petNames.size - displayNames.size).coerceAtLeast(0)
-
-    // (아이콘 32dp, 겹침 12dp -> (3-1)*20 + 32 = 72dp)
-    // (남은 숫자(+N) 너비 24dp)
     val width = (32 + (displayNames.size - 1) * 20 + (if (remaining > 0) 24 else 0)).dp
-    val overlap = 20.dp // 겹치는 너비 (32dp 아이콘 기준)
+    val overlap = 20.dp
 
     Box(
-        modifier = modifier
-            .width(width)
-            .height(32.dp),
+        modifier = modifier.width(width).height(32.dp),
         contentAlignment = Alignment.CenterStart
     ) {
-        // (수정) 뒤에서부터 그림 (Z-index)
         displayNames.reversed().forEachIndexed { index, name ->
             PetIconCircle(
                 petName = name,
                 color = color.copy(alpha = 1f - (index * 0.2f)),
-                modifier = Modifier
-                    .padding(start = ((displayNames.size - 1) - index) * overlap)
-                    .size(32.dp)
+                modifier = Modifier.padding(start = ((displayNames.size - 1) - index) * overlap).size(32.dp)
             )
         }
-
-        // "+N" 텍스트 (4개 이상일 때)
         if (remaining > 0) {
             Box(
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .background(Color.Gray.copy(alpha = 0.3f)),
+                modifier = Modifier.align(Alignment.CenterEnd).size(24.dp).clip(CircleShape).background(Color.Gray.copy(alpha = 0.3f)),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = "+$remaining",
-                    fontSize = 9.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = color
-                )
+                Text(text = "+$remaining", fontSize = 9.sp, fontWeight = FontWeight.Bold, color = color)
             }
         }
     }
 }
 
-// (기존) 펫 아이콘 헬퍼
 @Composable
 private fun PetIconCircle(petName: String, color: Color, modifier: Modifier = Modifier) {
     Box(
-        modifier = modifier
-            .clip(CircleShape)
-            .background(Color.Gray.copy(alpha = 0.1f)),
+        modifier = modifier.clip(CircleShape).background(Color.Gray.copy(alpha = 0.1f)),
         contentAlignment = Alignment.Center
     ) {
-        Icon(
-            imageVector = Icons.Default.Pets,
-            contentDescription = petName,
-            tint = color,
-            modifier = Modifier.size(20.dp)
-        )
+        Icon(imageVector = Icons.Default.Pets, contentDescription = petName, tint = color, modifier = Modifier.size(20.dp))
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
@@ -282,6 +282,17 @@ fun DailyHeader(selectedDate: LocalDate) {
     }
 }
 
+// 한글 받침 확인 함수
+fun hasBatchim(text: String): Boolean {
+    if (text.isEmpty()) return false
+    val lastChar = text.last()
+
+    // 한글 유니코드 범위: 가(0xAC00) ~ 힣(0xD7A3)
+    if (lastChar < '\uAC00' || lastChar > '\uD7A3') return false
+
+    // (글자 - 0xAC00) % 28 의 결과가 0보다 크면 받침이 있는 것
+    return (lastChar.code - 0xAC00) % 28 > 0
+}
 @Composable
 fun TodoGroupCard(
     group: TodoGroup,
@@ -299,17 +310,18 @@ fun TodoGroupCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, end = 4.dp),
+                    .padding(start = 23.dp, end = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 val assigneeName = group.assigneeName ?: ""
+                val particle = if (hasBatchim(assigneeName)) "이" else "가"
                 Text(
                     text = buildAnnotatedString {
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.SemiBold, fontSize = 14.sp)) {
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.SemiBold, fontSize = 18.sp)) {
                             append(assigneeName)
                         }
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Medium, fontSize = 10.sp)) {
-                            append("(이)가")
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Medium, fontSize = 15.sp)) {
+                            append(particle)
                         }
                     },
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -375,7 +387,7 @@ fun TaskItemRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .height(40.dp)
             .padding(horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -392,7 +404,7 @@ fun TaskItemRow(
             text = task.title ?: "",
             modifier = Modifier
                 .weight(1f)
-                .padding(start = 8.dp),
+                .padding(start = 3.dp),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.Medium,
             fontSize = 15.sp,

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
@@ -1,8 +1,11 @@
 package com.example.howsu.screen.todo
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
+// import androidx.compose.material.icons.filled.ArrowBackIosNew // ★ 2. (삭제)
+// import androidx.compose.material.icons.filled.ArrowForwardIos // ★ 3. (삭제)
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border // ★ (신규) border 임포트
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,10 +24,13 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Pets
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,8 +39,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -45,15 +53,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.times
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -63,6 +73,11 @@ import com.example.howsu.common.MyFloatingActionButton
 import com.example.howsu.data.model.Task
 import com.example.howsu.data.model.TodoGroup
 import com.example.howsu.ui.theme.HowsuTheme
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -71,19 +86,37 @@ fun TodoScreen(
     navController: NavHostController,
     viewModel: TodoViewModel = viewModel()
 ) {
-    // ViewModel로부터 실시간 데이터 목록(List<TodoGroup>) 가져오기
-    val todoGroups by viewModel.todoGroups.collectAsState()
+    val todoGroups by viewModel.todoGroups.collectAsState(initial = emptyList())
+    val selectedDate by viewModel.selectedDate.collectAsState()
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.selectDateFromPicker(datePickerState.selectedDateMillis)
+                    showDatePicker = false
+                }) { Text("확인") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("취소") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
-        // --- 상단 앱 바 ---
         topBar = {
             TopAppBar(
                 title = { Text("Todo", fontWeight = FontWeight.Medium, fontSize = 24.sp) },
                 actions = {
-                    IconButton(onClick = {
-                        navController.navigate("schedule")
-                    }) {
+                    IconButton(onClick = { showDatePicker = true }) {
                         Icon(
                             painter = painterResource(id = R.drawable.date_under),
                             contentDescription = "캘린더",
@@ -96,45 +129,172 @@ fun TodoScreen(
                 )
             )
         },
-        // --- 하단 네비게이션 바 ---
         bottomBar = {
             MyBottomNavigationBar(navController = navController)
         },
-        // --- 플로팅 버튼 ---
         floatingActionButton = {
             MyFloatingActionButton(
-                onTodoClick = {
-                    navController.navigate("create_todo")
-                },
-                onScheduleClick = {
-                    navController.navigate("create_schedule")
-                },
-                onFeedCreateClick = {
-                    navController.navigate("create_feed")
-                }
-
+                onTodoClick = { navController.navigate("create_todo") },
+                onScheduleClick = { navController.navigate("create_schedule") },
+                onFeedCreateClick = { navController.navigate("create_feed") }
             )
         }
     ) { innerPadding ->
-        // --- 본문 (할 일 목록) ---
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .padding(innerPadding)
-                .fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
+                .fillMaxSize()
         ) {
-            items(todoGroups) { group ->
-                TodoGroupCard(
-                    group = group,
-                    navController = navController,
-                    viewModel = viewModel
-                )
+            val today = LocalDate.now() // ★ (신규) 오늘 날짜 가져오기
+
+            CalendarWeekRow(
+                selectedDate = selectedDate,
+                today = today, // ★ (신규) 오늘 날짜 전달
+                onDateChange = viewModel::onDateChange,
+                onWeekDaySelected = viewModel::onWeekDaySelected
+            )
+
+            DailyHeader(selectedDate = selectedDate)
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                items(todoGroups, key = { it.documentId }) { group ->
+                    TodoGroupCard(
+                        group = group,
+                        navController = navController,
+                        viewModel = viewModel
+                    )
+                }
             }
         }
     }
 }
 
+// ★★★ 5. (수정) 주간 캘린더 (스와이프 + 동그라미 + 테두리) ★★★
+@Composable
+fun CalendarWeekRow(
+    selectedDate: LocalDate,
+    today: LocalDate, // ★ (신규) '오늘' 날짜 받기
+    onDateChange: (days: Long) -> Unit, // (Boolean -> Long)
+    onWeekDaySelected: (LocalDate) -> Unit
+) {
+    val startOfWeek = selectedDate.with(DayOfWeek.SUNDAY)
+    val weekDates = List(7) { i -> startOfWeek.plusDays(i.toLong()) }
+
+    val dayFormatter = DateTimeFormatter.ofPattern("d", Locale.KOREAN)
+    val dayOfWeekFormatter = DateTimeFormatter.ofPattern("E", Locale.KOREAN)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp, horizontal = 16.dp)
+            // ★ (신규) 스와이프 제스처 추가
+            .pointerInput(Unit) {
+                var totalDragAmount = 0f // 1. 드래그 거리를 저장할 변수
+
+                detectHorizontalDragGestures(
+                    // 2. 드래그하는 동안 x축 이동 거리를 totalDragAmount에 누적
+                    onHorizontalDrag = { change, dragAmount ->
+                        change.consume()
+                        totalDragAmount += dragAmount
+                    },
+                    // 3. 드래그가 끝나면(손가락을 떼면)
+                    onDragEnd = {
+                        if (totalDragAmount > 50) { // ★ 오른쪽으로 50px 이상
+                            onDateChange(-7) // 이전 주 (7일 빼기)
+                        } else if (totalDragAmount < -50) { // ★ 왼쪽으로 50px 이상
+                            onDateChange(7) // 다음 주 (7일 더하기)
+                        }
+                        totalDragAmount = 0f // 4. 거리 리셋
+                    },
+                    // 5. 드래그가 취소돼도 리셋
+                    onDragCancel = {
+                        totalDragAmount = 0f
+                    }
+                )
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceAround // ★ (수정) SpaceEvenly -> SpaceAround
+    ) {
+        // ★ (삭제) < 버튼
+
+        weekDates.forEach { date ->
+            val isSelected = date == selectedDate
+            val isToday = date == today // ★ (신규) 오늘인지 확인
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .weight(1f) // ★ 동일 너비
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onWeekDaySelected(date) }
+                    .padding(vertical = 8.dp, horizontal = 4.dp)
+            ) {
+                // "월"
+                Text(
+                    text = date.format(dayOfWeekFormatter),
+                    fontSize = 12.sp,
+                    color = Color.Gray // ★ 선택 여부와 관계없이 회색
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // "17" (★ 수정 - 동그라미/테두리)
+                Box(
+                    modifier = Modifier
+                        .size(32.dp) // 동그라미 크기
+                        .clip(CircleShape)
+                        .background(
+                            if (isSelected) Color.Black else Color.Transparent // ★ 선택 시 검은 배경
+                        )
+                        .then(
+                            // ★ (신규) 오늘이고, 선택되지 않았을 때만 테두리
+                            if (isToday && !isSelected) {
+                                Modifier.border(1.5.dp, Color.Black, CircleShape)
+                            } else {
+                                Modifier
+                            }
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = date.format(dayFormatter),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (isSelected) Color.White else Color.Black // ★ 선택 시 흰색
+                    )
+                }
+            }
+        }
+
+        // ★ (삭제) > 버튼
+    }
+}
+
+// (기존) 날짜 헤더 (변경 없음)
+@Composable
+fun DailyHeader(selectedDate: LocalDate) {
+    val formatter = DateTimeFormatter.ofPattern("M월 d일 E요일", Locale.KOREAN)
+    val isToday = selectedDate == LocalDate.now()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = selectedDate.format(formatter) + if (isToday) " (오늘)" else "",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+
+// (기존) TodoGroupCard (변경 없음)
 @Composable
 fun TodoGroupCard(
     group: TodoGroup,
@@ -159,50 +319,28 @@ fun TodoGroupCard(
                     .padding(start = 16.dp, end = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                val assigneeName = group.assigneeName ?: ""
                 Text(
                     text = buildAnnotatedString {
-                        val mainName = group.assigneeName.substringBefore("(", group.assigneeName)
                         withStyle(style = SpanStyle(fontWeight = FontWeight.SemiBold, fontSize = 14.sp)) {
-                            append(mainName)
+                            append(assigneeName)
                         }
-                        if (group.assigneeName.contains("(")) {
-                            val particle = "(${group.assigneeName.substringAfter("(", "")}"
-                            withStyle(style = SpanStyle(fontWeight = FontWeight.Medium, fontSize = 10.sp)) {
-                                append(particle)
-                            }
+                        withStyle(style = SpanStyle(fontWeight = FontWeight.Medium, fontSize = 10.sp)) {
+                            append("(이)가")
                         }
                     },
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.weight(1f))
 
-                // 1. 'var' 변수를 'val' 지역 변수로 복사 (스마트 캐스트 문제 해결)
-                val profileRes = group.assigneeProfileRes
-
-                // 2. 'val' 변수(profileRes)를 사용
-                if (profileRes != null) {
-                    Image(
-                        painter = painterResource(id = profileRes), // ★ 'val' 변수 사용
-                        contentDescription = "${group.assigneeName} 프로필",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .size(34.dp)
-                            .clip(CircleShape)
-                            .border(BorderStroke(1.dp, Color.LightGray), CircleShape)
-                    )
-                } else {
-                    // Placeholder
-                    Box(
-                        modifier = Modifier
-                            .size(34.dp)
-                            .border(BorderStroke(1.dp, Color.LightGray), CircleShape)
-                    )
-                }
+                OverlappingPetIcons(
+                    petNames = group.petNames,
+                    color = Color.Black,
+                    modifier = Modifier.height(34.dp)
+                )
 
                 Box {
-                    IconButton(onClick = {
-                        isMenuExpanded = true
-                    }) {
+                    IconButton(onClick = { isMenuExpanded = true }) {
                         Icon(
                             Icons.Default.MoreVert,
                             contentDescription = "더보기",
@@ -211,21 +349,19 @@ fun TodoGroupCard(
                     }
                     DropdownMenu(
                         expanded = isMenuExpanded,
-                        onDismissRequest = {
-                            isMenuExpanded = false
-                        }
+                        onDismissRequest = { isMenuExpanded = false }
                     ) {
                         DropdownMenuItem(
                             text = { Text("수정하기") },
                             onClick = {
-                                navController.navigate("edit_todo/${group.id}")
+                                navController.navigate("edit_todo/${group.documentId}")
                                 isMenuExpanded = false
                             }
                         )
                         DropdownMenuItem(
                             text = { Text("삭제하기") },
                             onClick = {
-                                viewModel.deleteGroup(group.id)
+                                viewModel.deleteGroup(group.documentId)
                                 isMenuExpanded = false
                             }
                         )
@@ -235,48 +371,58 @@ fun TodoGroupCard(
 
             Spacer(modifier = Modifier.height(1.dp))
 
-            // --- (Column과 tasks.forEach 부분은 동일) ---
             Column(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 group.tasks.forEach { task ->
-                    TaskItemRow(task = task)
+                    TaskItemRow(
+                        task = task,
+                        onCheckedChange = { isChecked ->
+                            viewModel.onTaskCheckedChange(group.documentId, task.id, isChecked)
+                        }
+                    )
                 }
             }
         }
     }
 }
 
+// ★★★ 6. (수정) TaskItemRow (Row 전체 클릭) ★★★
 @Composable
-fun TaskItemRow(task: Task) {
-    var isChecked by remember { mutableStateOf(task.isChecked) }
-
+fun TaskItemRow(
+    task: Task,
+    onCheckedChange: (Boolean) -> Unit
+) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(4.dp))
+            .clickable { onCheckedChange(!task.isChecked) }, // ★ (신규) Row 전체 클릭
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(
-            checked = isChecked,
-            onCheckedChange = { isChecked = it },
+            checked = task.isChecked,
+            onCheckedChange = onCheckedChange,
             colors = CheckboxDefaults.colors(
                 checkedColor = MaterialTheme.colorScheme.primary,
                 uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant
             )
         )
         Text(
-            text = task.title,
+            text = task.title ?: "",
             modifier = Modifier
                 .padding(start = 0.5.dp)
                 .weight(0.5f),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.Medium,
             fontSize = 12.sp,
-            maxLines = 1
+            maxLines = 1,
+            textDecoration = if (task.isChecked) TextDecoration.LineThrough else TextDecoration.None
         )
         Spacer(modifier = Modifier.width(10.dp))
         Text(
-            text = task.date,
+            text = task.date ?: "",
             fontWeight = FontWeight.Medium,
             fontSize = 11.sp,
             color = Color.Black
@@ -284,11 +430,87 @@ fun TaskItemRow(task: Task) {
     }
 }
 
+
 @Preview(showBackground = true)
 @Composable
 fun TodoScreenPreview() {
     HowsuTheme {
         val navController = rememberNavController()
         TodoScreen(navController = navController)
+    }
+}
+
+// ★★★ 7. (수정) 펫 아이콘 (3개 + N개)
+@Composable
+private fun OverlappingPetIcons(
+    petNames: List<String>,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    if (petNames.isEmpty()) {
+        return
+    }
+
+    val displayNames = petNames.take(3) // ★ 최대 3개만 표시
+    val remaining = (petNames.size - displayNames.size).coerceAtLeast(0)
+
+    // (아이콘 32dp, 겹침 12dp -> (3-1)*20 + 32 = 72dp)
+    // (남은 숫자(+N) 너비 24dp)
+    val width = (32 + (displayNames.size - 1) * 20 + (if (remaining > 0) 24 else 0)).dp
+    val overlap = 20.dp // 겹치는 너비 (32dp 아이콘 기준)
+
+    Box(
+        modifier = modifier
+            .width(width)
+            .height(32.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        // (수정) 뒤에서부터 그림 (Z-index)
+        displayNames.reversed().forEachIndexed { index, name ->
+            PetIconCircle(
+                petName = name,
+                color = color.copy(alpha = 1f - (index * 0.2f)),
+                modifier = Modifier
+                    .padding(start = ((displayNames.size - 1) - index) * overlap)
+                    .size(32.dp)
+            )
+        }
+
+        // "+N" 텍스트 (4개 이상일 때)
+        if (remaining > 0) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(Color.Gray.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "+$remaining",
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = color
+                )
+            }
+        }
+    }
+}
+
+// (기존) 펫 아이콘 헬퍼
+@Composable
+private fun PetIconCircle(petName: String, color: Color, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(Color.Gray.copy(alpha = 0.1f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Pets,
+            contentDescription = petName,
+            tint = color,
+            modifier = Modifier.size(20.dp)
+        )
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoScreen.kt
@@ -120,7 +120,8 @@ fun TodoScreen(
                         Icon(
                             painter = painterResource(id = R.drawable.date_under),
                             contentDescription = "캘린더",
-                            modifier = Modifier.size(24.dp)
+                            modifier = Modifier.size(24.dp),
+                            tint = Color(0xFFFFC848)
                         )
                     }
                 },
@@ -224,8 +225,8 @@ fun CalendarWeekRow(
             // 2. 선택된 날짜(isSelected)이면서 오늘이 아님 = 검은색 테두리 + 검은색 글씨
             // 3. 그 외 = 투명 + 검은색 글씨
 
-            val backgroundColor = if (isToday) Color.Black else Color.Transparent
-            val borderColor = if (isSelected && !isToday) Color.Black else Color.Transparent
+            val backgroundColor = if (isToday) Color(0xFFFFC848) else Color.Transparent
+            val borderColor = if (isSelected && !isToday) Color(0xFFFFC848) else Color.Transparent
             val textColor = if (isToday) Color.White else Color.Black
 
             Column(
@@ -304,7 +305,10 @@ fun TodoGroupCard(
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        colors = CardDefaults.cardColors(
+            containerColor = Color(0xFFFFC848) // 원하시는 노란색 적용
+        )
+        // colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
         Column(modifier = Modifier.padding(vertical = 10.dp)) {
             Row(

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
@@ -9,21 +9,30 @@ import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
 import java.util.Locale
 
 class TodoViewModel : ViewModel() {
 
     private val db = Firebase.firestore
+
     private val _allTodoGroups = MutableStateFlow<List<TodoGroup>>(emptyList())
+
+    // ★ (수정) 초기화 시점에도 '지난 일요일'을 기준으로 설정 (앱 켜자마자 다음주가 보이는 문제 해결)
     private val _selectedDate = MutableStateFlow(LocalDate.now())
     val selectedDate = _selectedDate.asStateFlow()
+
+    private val _currentWeekStart = MutableStateFlow(
+        LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+    )
+    val currentWeekStart = _currentWeekStart.asStateFlow()
 
     val todoGroups = combine(_allTodoGroups, _selectedDate) { groups, date ->
         val formattedDate = date.format(DateTimeFormatter.ofPattern("yyyy. MM. dd", Locale.KOREA))
@@ -31,92 +40,65 @@ class TodoViewModel : ViewModel() {
         val groupsForDate = groups.mapNotNull { group ->
             val tasksForDate = group.tasks.filter { it.date == formattedDate }
             if (tasksForDate.isNotEmpty()) {
-                val sortedTasks = tasksForDate.sortedBy { it.isChecked }
-                group.copy(tasks = sortedTasks)
-            } else {
-                null
-            }
+                group.copy(tasks = tasksForDate.sortedBy { it.isChecked })
+            } else null
         }
 
-        groupsForDate.sortedBy { group ->
-            group.tasks.all { it.isChecked }
-        }
+        groupsForDate.sortedBy { it.tasks.all { task -> task.isChecked } }
     }
 
     init {
         fetchTodoGroups()
     }
 
+    // ★ (수정) 오늘 날짜로 리셋할 때도 '이번 주 일요일(시작일)'을 정확히 계산
+    fun resetToToday() {
+        val today = LocalDate.now()
+        _selectedDate.value = today
+        // "오늘이 포함된 주의 일요일"을 계산
+        _currentWeekStart.value = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+    }
+
     private fun fetchTodoGroups() {
         db.collection("todoGroups")
-            .addSnapshotListener { snapshot, error -> // ★ 실시간 리스너
+            .addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     Log.w("TodoViewModel", "Listen failed.", error)
                     return@addSnapshotListener
                 }
-
                 if (snapshot != null) {
                     val groups = snapshot.documents.mapNotNull { doc ->
                         try {
-                            // ★ documentId를 포함하여 객체로 변환
                             doc.toObject(TodoGroup::class.java)?.copy(documentId = doc.id)
                         } catch (e: Exception) {
-                            Log.e("TodoViewModel", "데이터 모델 변환 실패: ${doc.id}", e)
                             null
                         }
                     }
-                    _allTodoGroups.value = groups // ★ 리스너가 로컬 상태를 갱신
+                    _allTodoGroups.value = groups
                 }
             }
     }
 
     fun deleteGroup(documentId: String) {
         if (documentId.isBlank()) return
-        db.collection("todoGroups").document(documentId)
-            .delete()
-            .addOnSuccessListener { Log.d("TodoViewModel", "삭제 성공: $documentId") }
-            .addOnFailureListener { e -> Log.w("TodoViewModel", "삭제 실패", e) }
+        db.collection("todoGroups").document(documentId).delete()
     }
 
-    // ★★★ (대폭 수정) 태스크 체크/언체크 (깜빡임/정렬 버그 수정) ★★★
     fun onTaskCheckedChange(documentId: String, taskId: String, isChecked: Boolean) {
-        // ★ 1. 로컬 상태(_allTodoGroups.value)를 직접 수정하지 않음!
-
         viewModelScope.launch {
             try {
                 val docRef = db.collection("todoGroups").document(documentId)
-
-                // 2. Firestore에서 현재 'tasks' 배열을 가져옴
                 val document = docRef.get().await()
                 val group = document.toObject(TodoGroup::class.java) ?: return@launch
 
-                // 3. tasks 리스트에서 해당 task를 찾아 isChecked 업데이트
                 val newTasks = group.tasks.map { task ->
-                    if (task.id == taskId) {
-                        task.copy(isChecked = isChecked)
-                    } else {
-                        task
-                    }
+                    if (task.id == taskId) task.copy(isChecked = isChecked)
+                    else task
                 }
-
-                // 4. Firestore 문서의 'tasks' 필드만 업데이트
                 docRef.update("tasks", newTasks).await()
-                Log.d("TodoViewModel", "태스크 업데이트 성공: $taskId")
-
-                // 5. 업데이트가 성공하면, 'fetchTodoGroups'의 실시간 리스너가
-                //    자동으로 변경을 감지하고 _allTodoGroups.value를 갱신함.
-                //    (따라서 로컬 상태를 여기서 건드릴 필요가 없음)
-
             } catch (e: Exception) {
                 Log.e("TodoViewModel", "태스크 업데이트 실패", e)
             }
-        }
-    }
-
-    // ★ (수정) 7일씩 변경
-    fun onDateChange(days: Long) {
-        _selectedDate.update {
-            it.plusDays(days)
         }
     }
 
@@ -124,10 +106,23 @@ class TodoViewModel : ViewModel() {
         _selectedDate.value = date
     }
 
+    fun onWeekSwipe(days: Long) {
+        val newWeekStart = _currentWeekStart.value.plusDays(days)
+        _currentWeekStart.value = newWeekStart
+
+        val currentSelected = _selectedDate.value
+        if (currentSelected !in newWeekStart..newWeekStart.plusDays(6)) {
+            _selectedDate.value = newWeekStart.plusDays(if (days > 0) 0 else 6)
+        }
+    }
+
     fun selectDateFromPicker(millis: Long?) {
         if (millis == null) return
-        _selectedDate.value = Instant.ofEpochMilli(millis)
+        val newDate = Instant.ofEpochMilli(millis)
             .atZone(ZoneId.systemDefault())
             .toLocalDate()
+
+        _selectedDate.value = newDate
+        _currentWeekStart.value = newDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
@@ -1,77 +1,133 @@
 package com.example.howsu.screen.todo
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.howsu.data.model.TodoGroup
-import com.google.firebase.firestore.ktx.firestore // ★ Firebase Firestore 의존성 필요
-import com.google.firebase.firestore.ktx.toObjects
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class TodoViewModel : ViewModel() {
 
-    // 1. 실시간 할 일 목록을 담을 StateFlow
-    // (UI는 이 변수를 구독(collect)합니다)
-    private val _todoGroups = MutableStateFlow<List<TodoGroup>>(emptyList())
-    val todoGroups = _todoGroups.asStateFlow()
-
-    // 2. Firestore 인스턴스
     private val db = Firebase.firestore
+    private val _allTodoGroups = MutableStateFlow<List<TodoGroup>>(emptyList())
+    private val _selectedDate = MutableStateFlow(LocalDate.now())
+    val selectedDate = _selectedDate.asStateFlow()
+
+    val todoGroups = combine(_allTodoGroups, _selectedDate) { groups, date ->
+        val formattedDate = date.format(DateTimeFormatter.ofPattern("yyyy. MM. dd", Locale.KOREA))
+
+        val groupsForDate = groups.mapNotNull { group ->
+            val tasksForDate = group.tasks.filter { it.date == formattedDate }
+            if (tasksForDate.isNotEmpty()) {
+                val sortedTasks = tasksForDate.sortedBy { it.isChecked }
+                group.copy(tasks = sortedTasks)
+            } else {
+                null
+            }
+        }
+
+        groupsForDate.sortedBy { group ->
+            group.tasks.all { it.isChecked }
+        }
+    }
 
     init {
-        // 3. ViewModel이 생성되자마자 Firestore의 "todoGroups" 컬렉션을 구독
         fetchTodoGroups()
     }
 
     private fun fetchTodoGroups() {
-        // "todoGroups" 컬렉션의 변경을 실시간으로 감지
         db.collection("todoGroups")
-            .addSnapshotListener { snapshot, error ->
+            .addSnapshotListener { snapshot, error -> // ★ 실시간 리스너
                 if (error != null) {
-                    // 에러 처리
+                    Log.w("TodoViewModel", "Listen failed.", error)
                     return@addSnapshotListener
                 }
 
                 if (snapshot != null) {
-                    // 4. Firestore 문서를 TodoGroup 객체 리스트로 변환
-                    val groups = snapshot.toObjects<TodoGroup>()
-                    // 5. StateFlow에 새 리스트를 업데이트 (UI가 자동으로 새로고침됨)
-                    _todoGroups.value = groups
+                    val groups = snapshot.documents.mapNotNull { doc ->
+                        try {
+                            // ★ documentId를 포함하여 객체로 변환
+                            doc.toObject(TodoGroup::class.java)?.copy(documentId = doc.id)
+                        } catch (e: Exception) {
+                            Log.e("TodoViewModel", "데이터 모델 변환 실패: ${doc.id}", e)
+                            null
+                        }
+                    }
+                    _allTodoGroups.value = groups // ★ 리스너가 로컬 상태를 갱신
                 }
             }
     }
 
-    // 6. 삭제 함수 (DropdownMenu에서 사용)
-    fun deleteGroup(groupId: Int) {
-        viewModelScope.launch {
-            // 1. 'id' 필드 값이 'groupId'와 일치하는 문서를 찾습니다.
-            db.collection("todoGroups")
-                .whereEqualTo("id", groupId) // ★ 우리가 저장한 숫자 ID로 검색
-                .get()
-                .addOnSuccessListener { querySnapshot ->
-                    // 2. 검색된 문서가 있다면
-                    if (querySnapshot.documents.isNotEmpty()) {
-                        // 3. 그 문서의 '진짜' ID (예: aBcD123Xyz)를 가져옵니다.
-                        val documentId = querySnapshot.documents[0].id
+    fun deleteGroup(documentId: String) {
+        if (documentId.isBlank()) return
+        db.collection("todoGroups").document(documentId)
+            .delete()
+            .addOnSuccessListener { Log.d("TodoViewModel", "삭제 성공: $documentId") }
+            .addOnFailureListener { e -> Log.w("TodoViewModel", "삭제 실패", e) }
+    }
 
-                        // 4. '진짜' ID를 사용해 문서를 삭제합니다.
-                        db.collection("todoGroups").document(documentId)
-                            .delete()
-                            .addOnSuccessListener {
-                                println("삭제 성공: $documentId")
-                                // (삭제가 성공하면 fetchTodoGroups()가 실시간으로 감지해서
-                                //  _todoGroups.value가 자동으로 업데이트됩니다)
-                            }
-                            .addOnFailureListener { e -> println("삭제 실패: $e") }
+    // ★★★ (대폭 수정) 태스크 체크/언체크 (깜빡임/정렬 버그 수정) ★★★
+    fun onTaskCheckedChange(documentId: String, taskId: String, isChecked: Boolean) {
+        // ★ 1. 로컬 상태(_allTodoGroups.value)를 직접 수정하지 않음!
+
+        viewModelScope.launch {
+            try {
+                val docRef = db.collection("todoGroups").document(documentId)
+
+                // 2. Firestore에서 현재 'tasks' 배열을 가져옴
+                val document = docRef.get().await()
+                val group = document.toObject(TodoGroup::class.java) ?: return@launch
+
+                // 3. tasks 리스트에서 해당 task를 찾아 isChecked 업데이트
+                val newTasks = group.tasks.map { task ->
+                    if (task.id == taskId) {
+                        task.copy(isChecked = isChecked)
                     } else {
-                        println("삭제할 문서를 찾지 못했습니다 (ID: $groupId)")
+                        task
                     }
                 }
-                .addOnFailureListener { e ->
-                    println("문서 검색 실패: $e")
-                }
+
+                // 4. Firestore 문서의 'tasks' 필드만 업데이트
+                docRef.update("tasks", newTasks).await()
+                Log.d("TodoViewModel", "태스크 업데이트 성공: $taskId")
+
+                // 5. 업데이트가 성공하면, 'fetchTodoGroups'의 실시간 리스너가
+                //    자동으로 변경을 감지하고 _allTodoGroups.value를 갱신함.
+                //    (따라서 로컬 상태를 여기서 건드릴 필요가 없음)
+
+            } catch (e: Exception) {
+                Log.e("TodoViewModel", "태스크 업데이트 실패", e)
+            }
         }
+    }
+
+    // ★ (수정) 7일씩 변경
+    fun onDateChange(days: Long) {
+        _selectedDate.update {
+            it.plusDays(days)
+        }
+    }
+
+    fun onWeekDaySelected(date: LocalDate) {
+        _selectedDate.value = date
+    }
+
+    fun selectDateFromPicker(millis: Long?) {
+        if (millis == null) return
+        _selectedDate.value = Instant.ofEpochMilli(millis)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate()
     }
 }

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.howsu.data.model.TodoGroup
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -48,18 +49,24 @@ class TodoViewModel : ViewModel() {
     }
 
     init {
+        // 초기화 시점에 데이터를 가져옴
         fetchTodoGroups()
     }
 
-    fun resetToToday() {
-        val today = LocalDate.now()
-        _selectedDate.value = today
-        // "오늘이 포함된 주의 일요일"을 계산
-        _currentWeekStart.value = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
-    }
-
     private fun fetchTodoGroups() {
+        val currentUser = Firebase.auth.currentUser
+        if (currentUser == null) {
+            _allTodoGroups.value = emptyList()
+            return
+        }
+
+        // ★ [핵심 로직]
+        // 가족 기능 구현 전: 내 UID를 familyId로 사용
+        // 가족 기능 구현 후: API로 받아온 shared_family_id를 사용하면 됨
+        val currentFamilyId = currentUser.uid
+
         db.collection("todoGroups")
+            .whereEqualTo("familyId", currentFamilyId) // ★ 이 조건이 있어야 내 것만 보임!
             .addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     Log.w("TodoViewModel", "Listen failed.", error)
@@ -76,6 +83,13 @@ class TodoViewModel : ViewModel() {
                     _allTodoGroups.value = groups
                 }
             }
+    }
+
+    fun resetToToday() {
+        val today = LocalDate.now()
+        _selectedDate.value = today
+        // "오늘이 포함된 주의 일요일"을 계산
+        _currentWeekStart.value = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
     }
 
     fun deleteGroup(documentId: String) {

--- a/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
+++ b/Howsu/app/src/main/java/com/example/howsu/screen/todo/TodoViewModel.kt
@@ -51,7 +51,6 @@ class TodoViewModel : ViewModel() {
         fetchTodoGroups()
     }
 
-    // ★ (수정) 오늘 날짜로 리셋할 때도 '이번 주 일요일(시작일)'을 정확히 계산
     fun resetToToday() {
         val today = LocalDate.now()
         _selectedDate.value = today
@@ -86,22 +85,34 @@ class TodoViewModel : ViewModel() {
 
     fun onTaskCheckedChange(documentId: String, taskId: String, isChecked: Boolean) {
         viewModelScope.launch {
+            val docRef = db.collection("todoGroups").document(documentId)
             try {
-                val docRef = db.collection("todoGroups").document(documentId)
-                val document = docRef.get().await()
-                val group = document.toObject(TodoGroup::class.java) ?: return@launch
+                // 'get'/'update' 대신 'transaction'을 사용
+                db.runTransaction { transaction ->
+                    val snapshot = transaction.get(docRef)
+                    val group = snapshot.toObject(TodoGroup::class.java)
+                        ?: throw Exception("Group not found") // 그룹이 없으면 중단
 
-                val newTasks = group.tasks.map { task ->
-                    if (task.id == taskId) task.copy(isChecked = isChecked)
-                    else task
-                }
-                docRef.update("tasks", newTasks).await()
+                    val newTasks = group.tasks.map { task ->
+                        if (task.id == taskId) {
+                            task.copy(isChecked = isChecked)
+                        } else {
+                            task
+                        }
+                    }
+
+                    transaction.update(docRef, "tasks", newTasks)
+
+                    // (트랜잭션이 성공하면 null을 반환)
+                    null
+                }.await()
+                // 트랜잭션이 성공하면 snapshotListener가 알아서 UI를 갱신합니다.
+
             } catch (e: Exception) {
-                Log.e("TodoViewModel", "태스크 업데이트 실패", e)
+                Log.e("TodoViewModel", "태스크 업데이트 실패 (Transaction)", e)
             }
         }
     }
-
     fun onWeekDaySelected(date: LocalDate) {
         _selectedDate.value = date
     }

--- a/Howsu/gradle/libs.versions.toml
+++ b/Howsu/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ activityCompose = "1.11.0"
 composeBom = "2024.09.00"
 navigation = "2.9.4"
 foundationLayout = "1.9.4"
+material3 = "1.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 androidx-navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigation"}
 androidx-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
+material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## ☑️ 체크리스트
- [x] open issue -> create branch -> dev -> push&commit -> pull request -> review -> merge -> close issue
*main 브랜치가 아닌 생성한 브랜치에서 작업, PR, 리뷰 확인 후 dev에 merge
- [x] Assignees & Labels & Development 할당

---

📌 𝗜𝘀𝘀𝘂𝗲𝘀
closed #23 

---

## 1️⃣ 작업에 대한 설명

1. 공유 가족 생성
UI/UX: 사용자가 가족 별칭을 입력하면 고유한 초대 코드가 발급됨
로직: Random 함수를 이용해 중복되지 않는 고유 ID를 생성, Firebase Firestore의 families 컬렉션에 새로운 문서를 생성
=> 생성한 유저는 자동으로 '방장(Owner)' 권한
초대: 생성된 ID와 QR 코드를 보여 주어 다른 가족 구성원이 쉽게 참여할 수 있도록 유도

2. 가족 참여하기
UI/UX: 초대받은 ID를 입력하고 검색 버튼을 누르면 즉시 해당 가족 그룹에 합류함
로직: 입력된 ID가 Firestore에 존재하는지 검증 후, 해당 가족 문서의 memberIds 필드에 유저 UID를 추가 
=> 동시에 members 하위 컬렉션에 유저 프로필을 생성하여 구성원으로 등록

3. 1인 가구 자동 생성
로직: '안 할래요'를 선택하더라도 시스템 내부적으로는 1인 그룹을 생성
=> 겉으로는 개인 앱처럼 보이지만, 실제로는 확장 가능한 그룹 형태이므로 언제든 친구나 가족을 초대하여 확장할 수 있음

4. 캘린더 알림 기능
로직: 사용자가 알림 시점을 선택하면 (10분 전, 1시간 전 등) 그때 알림 전송

---

## 2️⃣ 스크린샷
<img width="1080" height="2121" alt="image" src="https://github.com/user-attachments/assets/6486fddc-8bf0-4332-ba96-488dbc4f9587" />
<img width="1080" height="2121" alt="image" src="https://github.com/user-attachments/assets/65d5abc9-11a5-4273-b9c1-933cfb06b2b5" />
<img width="1080" height="2121" alt="image" src="https://github.com/user-attachments/assets/2602fcc0-95b2-4b53-8465-5c3e23725de5" />
<img width="1080" height="2121" alt="image" src="https://github.com/user-attachments/assets/e570cf3b-0778-4982-863d-a8ecf21db905" />


---

## 3️⃣ 참고 사항
- (관련 문서, 링크, 기타 메모)

